### PR TITLE
FIX: Demon base class depending on autoloader

### DIFF
--- a/lib/demon.rb
+++ b/lib/demon.rb
@@ -1,8 +1,14 @@
 # frozen_string_literal: true
 
-require_dependency 'demon/base'
+if Rails.autoloaders.main.class == Zeitwerk::Loader
+  require_dependency 'demon/demon_base'
+else
+  require_dependency 'demon/base'
+end
 
-class DiscoursePrometheus::Demon < Demon::Base
+base_class = Rails.autoloaders.main.class == Zeitwerk::Loader ? Demon::DemonBase : Demon::Base
+
+class DiscoursePrometheus::Demon < base_class
   def self.prefix
     "prometheus-demon"
   end


### PR DESCRIPTION
This is a temporary and hacky solution until deploying of Zeitwerk for core Discourse. In that PR https://github.com/discourse/discourse/pull/8098 demon base class was modified for Zeitwerk

The goal is here is the ability to safely merge that code before move Discourse to Zeitwerk. 