### PR TITLE
FEATURE: Add per-process metrics for Discourse readonly states

### DIFF
--- a/lib/internal_metric/process.rb
+++ b/lib/internal_metric/process.rb
@@ -15,7 +15,7 @@ module DiscoursePrometheus::InternalMetric
       deferred_jobs_queued: "Number of jobs queued in the deferred job queue",
       active_record_connections_count: "Total number of connections in ActiveRecord's connection pools",
       active_record_failover_count: "Count of ActiveRecord databases in a failover state",
-      redis_failover_count: "Count of redis backends in a failover state"
+      redis_failover_count: "Count of Redis servers in a failover state"
     }
 
     COUNTERS = {

--- a/lib/internal_metric/process.rb
+++ b/lib/internal_metric/process.rb
@@ -14,7 +14,8 @@ module DiscoursePrometheus::InternalMetric
       thread_count: "Total number of active threads per process",
       deferred_jobs_queued: "Number of jobs queued in the deferred job queue",
       active_record_connections_count: "Total number of connections in ActiveRecord's connection pools",
-      readonly_sites_count: "Number of sites currently in readonly mode. Key is one of Discourse::READONLY_KEYS, 'redis_recently_readonly' or 'postgres_recently_readonly'"
+      active_record_failover_count: "Count of activerecord backends in a failover state",
+      redis_failover_count: "Count of redis backends in a failover state"
     }
 
     COUNTERS = {
@@ -39,7 +40,8 @@ module DiscoursePrometheus::InternalMetric
       :created_at,
       :deferred_jobs_queued,
       :active_record_connections_count,
-      :readonly_sites_count
+      :active_record_failover_count,
+      :redis_failover_count
 
     def initialize
       @active_record_connections_count = {}

--- a/lib/internal_metric/process.rb
+++ b/lib/internal_metric/process.rb
@@ -13,7 +13,9 @@ module DiscoursePrometheus::InternalMetric
       rss: "Total RSS used by process",
       thread_count: "Total number of active threads per process",
       deferred_jobs_queued: "Number of jobs queued in the deferred job queue",
-      active_record_connections_count: "Total number of connections in ActiveRecord's connection pools"
+      active_record_connections_count: "Total number of connections in ActiveRecord's connection pools",
+      readonly: "Current per-site values for each key in Discourse::READONLY_KEYS",
+      last_readonly_seconds: "Local per-site per-process values for postgres and redis last_read_only values"
     }
 
     COUNTERS = {
@@ -37,7 +39,9 @@ module DiscoursePrometheus::InternalMetric
       :pid,
       :created_at,
       :deferred_jobs_queued,
-      :active_record_connections_count
+      :active_record_connections_count,
+      :last_readonly_seconds,
+      :readonly
 
     def initialize
       @active_record_connections_count = {}

--- a/lib/internal_metric/process.rb
+++ b/lib/internal_metric/process.rb
@@ -14,7 +14,7 @@ module DiscoursePrometheus::InternalMetric
       thread_count: "Total number of active threads per process",
       deferred_jobs_queued: "Number of jobs queued in the deferred job queue",
       active_record_connections_count: "Total number of connections in ActiveRecord's connection pools",
-      active_record_failover_count: "Count of activerecord backends in a failover state",
+      active_record_failover_count: "Count of ActiveRecord databases in a failover state",
       redis_failover_count: "Count of redis backends in a failover state"
     }
 

--- a/lib/internal_metric/process.rb
+++ b/lib/internal_metric/process.rb
@@ -14,8 +14,7 @@ module DiscoursePrometheus::InternalMetric
       thread_count: "Total number of active threads per process",
       deferred_jobs_queued: "Number of jobs queued in the deferred job queue",
       active_record_connections_count: "Total number of connections in ActiveRecord's connection pools",
-      readonly: "Current per-site values for each key in Discourse::READONLY_KEYS",
-      last_readonly_seconds: "Local per-site per-process values for postgres and redis last_read_only values"
+      readonly_sites_count: "Number of sites currently in readonly mode. Key is one of Discourse::READONLY_KEYS, 'redis_recently_readonly' or 'postgres_recently_readonly'"
     }
 
     COUNTERS = {
@@ -40,8 +39,7 @@ module DiscoursePrometheus::InternalMetric
       :created_at,
       :deferred_jobs_queued,
       :active_record_connections_count,
-      :last_readonly_seconds,
-      :readonly
+      :readonly_sites_count
 
     def initialize
       @active_record_connections_count = {}

--- a/lib/reporter/process.rb
+++ b/lib/reporter/process.rb
@@ -95,7 +95,6 @@ module DiscoursePrometheus::Reporter
     end
 
     def collect_failover_stats(metric)
-      dbs = RailsMultisite::ConnectionManagement.all_dbs
 
       if defined?(RailsFailover::ActiveRecord) && RailsFailover::ActiveRecord::Handler.instance.respond_to?(:primaries_down_count)
         metric.active_record_failover_count = RailsFailover::ActiveRecord::Handler.instance.primaries_down_count

--- a/lib/reporter/process.rb
+++ b/lib/reporter/process.rb
@@ -32,7 +32,7 @@ module DiscoursePrometheus::Reporter
       collect_process_stats(metric)
       collect_scheduler_stats(metric)
       collect_active_record_connections_stat(metric)
-      collect_readonly_mode_stats(metric)
+      collect_readonly_stats(metric)
       metric
     end
 
@@ -94,29 +94,36 @@ module DiscoursePrometheus::Reporter
       end
     end
 
-    def collect_readonly_mode_stats(metric)
+    def collect_readonly_stats(metric)
       dbs = RailsMultisite::ConnectionManagement.all_dbs
 
       # Dispose of old data
-      metric.readonly = {}
-      metric.last_readonly_seconds = {}
+      metric.readonly_sites_count = {}
 
       # This readonly info exists in redis. In theory it should be consistent across all processes
       # But if some processes have failed over to the redis replica, there could be discrepencies
       Discourse::READONLY_KEYS.each do |key|
         redis_keys = dbs.map { |db| "#{db}:#{key}" }
-        redis_values = Discourse.redis.without_namespace.mget(redis_keys)
-        dbs.each_with_index do |db, index|
-          metric.readonly[{ key: key, db: db }] = redis_values[index].to_i
-        end
+        count = Discourse.redis.without_namespace.exists(*redis_keys)
+        metric.readonly_sites_count[{ key: key }] = count
       end
 
       # This readonly info is stored in the local process.
       # postgres_last_read_only should be synced via DistributedCache, but this is not guaranteed
+      postgres_recently_readonly = 0
+      redis_recently_readonly = 0
+
+      # Discourse.recently_readonly? uses 15 seconds, but interval of process
+      # metric collection is 30 seconds so allow some extra time to avoid missing readonly changes
+      recent_threshold = 35.seconds.ago
+
       dbs.each do |db|
-        metric.last_readonly_seconds[{ store: "postgres", db: db }] = Discourse.postgres_last_read_only[db].to_i
-        metric.last_readonly_seconds[{ store: "redis", db: db }] = Discourse.redis_last_read_only[db].to_i
+        postgres_recently_readonly += 1 if Discourse.postgres_last_read_only[db].to_i > recent_threshold.to_i
+        redis_recently_readonly += 1 if Discourse.redis_last_read_only[db].to_i > recent_threshold.to_i
       end
+
+      metric.readonly_sites_count[{ key: "postgres_recently_readonly" }] = postgres_recently_readonly
+      metric.readonly_sites_count[{ key: "redis_recently_readonly" }] = redis_recently_readonly
     end
   end
 end

--- a/spec/lib/reporter/process_spec.rb
+++ b/spec/lib/reporter/process_spec.rb
@@ -24,40 +24,11 @@ module DiscoursePrometheus
         :v8_heap_count, :v8_physical_size, :pid, :rss, :thread_count)
     end
 
-    describe "with readonly mode cleanup" do
-      after do
-        Discourse.disable_readonly_mode(Discourse::PG_FORCE_READONLY_MODE_KEY)
-        Discourse.clear_readonly!
-      end
+    it "can collect failover data" do
+      metric = Reporter::Process.new(:web).collect
 
-      it "can collect readonly data from the redis keys" do
-        metric = Reporter::Process.new(:web).collect
-
-        Discourse::READONLY_KEYS.each do |k|
-          expect(metric.readonly_sites_count[key: k]).to eq(0)
-        end
-
-        Discourse.enable_readonly_mode(Discourse::PG_FORCE_READONLY_MODE_KEY)
-
-        metric = Reporter::Process.new(:web).collect
-        Discourse::READONLY_KEYS.each do |k|
-          expect(metric.readonly_sites_count[key: k]).to eq(k == Discourse::PG_FORCE_READONLY_MODE_KEY ? 1 : 0)
-        end
-      end
-
-      it "can collect recently readonly data" do
-        freeze_time
-
-        metric = Reporter::Process.new(:web).collect
-        expect(metric.readonly_sites_count[{ key: 'redis_recently_readonly' }]).to eq(0)
-        expect(metric.readonly_sites_count[{ key: 'postgres_recently_readonly' }]).to eq(0)
-
-        Discourse.received_redis_readonly!
-
-        metric = Reporter::Process.new(:web).collect
-        expect(metric.readonly_sites_count[{ key: 'redis_recently_readonly' }]).to eq(1)
-        expect(metric.readonly_sites_count[{ key: 'postgres_recently_readonly' }]).to eq(0)
-      end
+      expect(metric.active_record_failover_count).to eq(0)
+      expect(metric.redis_failover_count).to eq(0)
     end
   end
 end

--- a/spec/lib/reporter/process_spec.rb
+++ b/spec/lib/reporter/process_spec.rb
@@ -23,5 +23,47 @@ module DiscoursePrometheus
         :minor_gc_count, :total_allocated_objects, :v8_heap_size,
         :v8_heap_count, :v8_physical_size, :pid, :rss, :thread_count)
     end
+
+    describe "with readonly mode cleanup" do
+      after do
+        Discourse.disable_readonly_mode(Discourse::PG_FORCE_READONLY_MODE_KEY)
+        Discourse.clear_readonly!
+      end
+
+      it "can collect readonly stats" do
+        metric = Reporter::Process.new(:web).collect
+        expect(metric.readonly).to eq(
+          Discourse::READONLY_KEYS.map do |k|
+            [{ db: 'default', key: k }, 0 ]
+          end.to_h
+        )
+        Discourse.enable_readonly_mode(Discourse::PG_FORCE_READONLY_MODE_KEY)
+
+        metric = Reporter::Process.new(:web).collect
+        expect(metric.readonly).to eq(
+          Discourse::READONLY_KEYS.map do |k|
+            [{ db: 'default', key: k }, (k == Discourse::PG_FORCE_READONLY_MODE_KEY) ? 1 : 0]
+          end.to_h
+        )
+      end
+
+      it "can collect last_readonly_seconds stats" do
+        freeze_time
+
+        metric = Reporter::Process.new(:web).collect
+        expect(metric.last_readonly_seconds).to eq(
+          { db: 'default', store: 'redis' } => 0,
+          { db: 'default', store: 'postgres' } => 0
+        )
+
+        Discourse.received_redis_readonly!
+
+        metric = Reporter::Process.new(:web).collect
+        expect(metric.last_readonly_seconds).to eq(
+          { db: 'default', store: 'redis' } => Time.zone.now.to_i,
+          { db: 'default', store: 'postgres' } => 0
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
Two new metrics are introduced:
  active_record_failover_count: "Count of ActiveRecord databases in a failover state",
  redis_failover_count: "Count of Redis servers in a failover state"

This leans on counts from the rails_failover gem.