### PR TITLE
FEATURE: Add global metrics for Discourse readonly state

### DIFF
--- a/lib/collector.rb
+++ b/lib/collector.rb
@@ -176,6 +176,11 @@ module ::DiscoursePrometheus
         "Revision number of discourse starting from HEAD"
       )
 
+      global_metrics << Gauge.new(
+        "readonly_sites",
+        "Count of sites currently in readonly mode, grouped by the relevant key from Discourse::READONLY_KEYS"
+      )
+
       @global_metrics = global_metrics
     end
 

--- a/spec/lib/reporter/global_spec.rb
+++ b/spec/lib/reporter/global_spec.rb
@@ -24,5 +24,27 @@ module DiscoursePrometheus
     ensure
       metric.reset!
     end
+
+    describe "with readonly mode cleanup" do
+      after do
+        Discourse.disable_readonly_mode(Discourse::PG_FORCE_READONLY_MODE_KEY)
+        Discourse.clear_readonly!
+      end
+
+      it "can collect readonly data from the redis keys" do
+        metric = Reporter::Global.new.collect
+
+        Discourse::READONLY_KEYS.each do |k|
+          expect(metric.readonly_sites[key: k]).to eq(0)
+        end
+
+        Discourse.enable_readonly_mode(Discourse::PG_FORCE_READONLY_MODE_KEY)
+
+        metric = Reporter::Global.new.collect
+        Discourse::READONLY_KEYS.each do |k|
+          expect(metric.readonly_sites[key: k]).to eq(k == Discourse::PG_FORCE_READONLY_MODE_KEY ? 1 : 0)
+        end
+      end
+    end
   end
 end

--- a/spec/lib/reporter/global_spec.rb
+++ b/spec/lib/reporter/global_spec.rb
@@ -44,6 +44,8 @@ module DiscoursePrometheus
         Discourse::READONLY_KEYS.each do |k|
           expect(metric.readonly_sites[key: k]).to eq(k == Discourse::PG_FORCE_READONLY_MODE_KEY ? 1 : 0)
         end
+      ensure
+        metric.reset!
       end
     end
   end


### PR DESCRIPTION
discourse_readonly_sites: Count of sites currently in readonly mode, grouped by the relevant key from Discourse::READONLY_KEYS