### PR TITLE
FIX: When S3 inventory disabled for a DB don't collect missing uploads metric

### DIFF
--- a/lib/internal_metric/global.rb
+++ b/lib/internal_metric/global.rb
@@ -218,6 +218,7 @@ module DiscoursePrometheus::InternalMetric
       if Discourse.respond_to?(:stats) && (!last_check || (Time.now.to_i - last_check > MISSING_UPLOADS_CHECK_SECONDS))
         begin
           RailsMultisite::ConnectionManagement.each_connection do |db|
+            next if !SiteSetting.enable_s3_inventory
             @@missing_uploads[type][:stats][{ db: db }] = Discourse.stats.get("missing_#{type}_uploads")
           end
 


### PR DESCRIPTION
Because we expose `Discourse.stats` in core, there is nothing really to stop something writing directly to the `missing_s3_uploads` guage even if the S3 inventory is disabled. Now, when `enable_s3_inventory` is false we do not expose the `missing_s3_uploads` metric for the associated DB.