### PR TITLE
FIX: Run the global reporter in its own demon process

### DIFF
--- a/bin/collector
+++ b/bin/collector
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+Process.setproctitle("discourse prometheus-collector")
+
 version = File.read(File.expand_path("../../prometheus_exporter_version", __FILE__)).strip
 spec_file = File.expand_path("../../gems/#{RUBY_VERSION}/specifications/prometheus_exporter-#{version}.gemspec", __FILE__)
 

--- a/lib/collector_demon.rb
+++ b/lib/collector_demon.rb
@@ -2,9 +2,9 @@
 #
 require_dependency 'demon/base'
 
-class DiscoursePrometheus::Demon < ::Demon::Base
+class DiscoursePrometheus::CollectorDemon < ::Demon::Base
   def self.prefix
-    "prometheus-demon"
+    "prometheus-collector"
   end
 
   def run

--- a/lib/global_reporter_demon.rb
+++ b/lib/global_reporter_demon.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+#
+require_dependency 'demon/base'
+
+class DiscoursePrometheus::GlobalReporterDemon < ::Demon::Base
+  def self.prefix
+    "prometheus-global-reporter"
+  end
+
+  def suppress_stdout
+    false
+  end
+
+  def suppress_stderr
+    false
+  end
+
+  def after_fork
+    STDERR.puts "#{Time.now}: Starting Prometheus global reporter pid: #{Process.pid}"
+    t = DiscoursePrometheus::Reporter::Global.start($prometheus_client)
+    t.join
+  end
+end


### PR DESCRIPTION
Running a thread which makes postgres connections in the master unicorn
process can lead to unexpected failures in forked processes.