### PR TITLE
Check github actions weekly with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"


### PR DESCRIPTION
Similarly to the PR linked below, this change allows dependabot to check github actions which this project uses and submit PRs with version bumps.

https://github.com/discourse/discourse/pull/11411