### PR TITLE
Demon improvements

### DIFF
--- a/lib/global_reporter_demon.rb
+++ b/lib/global_reporter_demon.rb
@@ -19,9 +19,9 @@ class DiscoursePrometheus::GlobalReporterDemon < ::Demon::Base
     STDERR.puts "#{Time.now}: Starting Prometheus global reporter pid: #{Process.pid}"
     t = DiscoursePrometheus::Reporter::Global.start($prometheus_client)
 
-    trap('INT')  { t.kill }
-    trap('TERM') { t.kill }
-    trap('QUIT') { t.kill }
+    trap('INT')  { DiscoursePrometheus::Reporter::Global.stop }
+    trap('TERM') { DiscoursePrometheus::Reporter::Global.stop }
+    trap('QUIT') { DiscoursePrometheus::Reporter::Global.stop }
 
     t.join
     STDERR.puts "#{Time.now}: Stopping Prometheus global reporter pid: #{Process.pid}"

--- a/lib/global_reporter_demon.rb
+++ b/lib/global_reporter_demon.rb
@@ -18,6 +18,13 @@ class DiscoursePrometheus::GlobalReporterDemon < ::Demon::Base
   def after_fork
     STDERR.puts "#{Time.now}: Starting Prometheus global reporter pid: #{Process.pid}"
     t = DiscoursePrometheus::Reporter::Global.start($prometheus_client)
+
+    trap('INT')  { t.kill }
+    trap('TERM') { t.kill }
+    trap('QUIT') { t.kill }
+
     t.join
+    STDERR.puts "#{Time.now}: Stopping Prometheus global reporter pid: #{Process.pid}"
+    exit 0
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -50,8 +50,11 @@ after_initialize do
   # creates no new threads, this simply adds the instruments
   DiscoursePrometheus::Reporter::Web.start($prometheus_client) unless Rails.env.test?
 
-  # happens once per rack application
-  if Discourse.running_in_rack?
+  if respond_to? :register_demon_process
+    register_demon_process(DiscoursePrometheus::CollectorDemon)
+    register_demon_process(DiscoursePrometheus::GlobalReporterDemon)
+  elsif Discourse.running_in_rack?
+    # TODO: Remove once Discourse 2.7 stable is released
     Thread.new do
       begin
         DiscoursePrometheus::CollectorDemon.start


### PR DESCRIPTION
- FIX: Ensure the global reporter demon exits cleanly

- DEV: Move to new register_demon_process plugin API

  This allows the unicorn master to take care of starting and monitoring the demon. It also means the demon is started after all app/plugin initialization has completed.

  This change is backwards compatible.