### PR TITLE
FIX: Replace `version` integer metric with new `version_info` metric

### DIFF
--- a/lib/collector.rb
+++ b/lib/collector.rb
@@ -172,8 +172,8 @@ module ::DiscoursePrometheus
       )
 
       global_metrics << Gauge.new(
-        "version",
-        "Revision number of discourse starting from HEAD"
+        "version_info",
+        "Labelled with `revision` (current core commit hash), and `version` (Discourse::VERSION::STRING)"
       )
 
       global_metrics << Gauge.new(

--- a/spec/lib/internal_metric/global_spec.rb
+++ b/spec/lib/internal_metric/global_spec.rb
@@ -20,6 +20,8 @@ module DiscoursePrometheus::InternalMetric
     end
 
     it "can collect the version_info metric" do
+      metric.collect
+
       expect(metric.version_info.count).to eq(1)
       labels = metric.version_info.keys.first
       value = metric.version_info.values.first

--- a/spec/lib/internal_metric/global_spec.rb
+++ b/spec/lib/internal_metric/global_spec.rb
@@ -19,6 +19,16 @@ module DiscoursePrometheus::InternalMetric
       expect(metric.postgres_replica_available).to eq(nil)
     end
 
+    it "can collect the version_info metric" do
+      expect(metric.version_info.count).to eq(1)
+      labels = metric.version_info.keys.first
+      value = metric.version_info.values.first
+
+      expect(labels[:revision]).to match(/\A[0-9a-f]{40}\z/)
+      expect(labels[:version]).to eq(Discourse::VERSION::STRING)
+      expect(value).to eq(1)
+    end
+
     describe "missing_s3_uploads metric" do
       before do
         SiteSetting.enable_s3_uploads = true


### PR DESCRIPTION
The previous `git ref-list --count` metric does not work with shallow
clones of Discourse. With the latest Discourse base image, the number
returned will not be useful for comparisons.

This commit replaces the `version` metric with a `version_info` metric.

This always has a value of `1`. It has a `revision` label containing
the current discourse core commit hash, and a `version` label containing
the human-friendly `Discourse::VERSION::STRING`.

Output looks like

```
# HELP discourse_version_info Labelled with `revision` (current core commit hash), and `version` (Discourse::VERSION::STRING)
# TYPE discourse_version_info gauge
discourse_version_info{revision="35a2da32f29856e4d048d6856b825ed9d7a988c6",version="2.7.0.beta2"} 1
```