### PR TITLE
SECURITY: /metrics accessible from public IP addresses

### DIFF
--- a/lib/middleware/metrics.rb
+++ b/lib/middleware/metrics.rb
@@ -20,12 +20,10 @@ module DiscoursePrometheus
 
     private
 
-    PRIVATE_IP = /^(127\.)|(192\.168\.)|(10\.)|(172\.1[6-9]\.)|(172\.2[0-9]\.)|(172\.3[0-1]\.)|(::1$)|([fF][cCdD])/
-
     def is_private_ip?(env)
       request = Rack::Request.new(env)
       ip = IPAddr.new(request.ip) rescue nil
-      !!(ip && ip.to_s =~ PRIVATE_IP)
+      !!(ip && (ip.private? || ip.loopback?))
     end
 
     def is_trusted_ip?(env)

--- a/spec/middleware/metrics_spec.rb
+++ b/spec/middleware/metrics_spec.rb
@@ -30,16 +30,27 @@ describe ::DiscoursePrometheus::Middleware::Metrics do
     expect(status).to eq(404)
   end
 
-  it "can proxy the dedicated port" do
+  it "will 404 for public IP addresses" do
+    addresses = %w[62.127.0.1 62.192.168.1 62.10.0.0 62.172.16.0 62.172.21.0 62.172.31.0 2001:fc00:ffff:ffff:ffff:ffff:ffff:ffff]
+    addresses.each do |ip|
+      status, = middleware.call("PATH_INFO" => '/metrics', "REMOTE_ADDR" => ip, "rack.input" => StringIO.new)
+      expect(status).to eq(404)
+    end
+  end
+
+  it "can proxy the dedicated port for private IP addresses" do
     stub_request(:get, "http://localhost:#{GlobalSetting.prometheus_collector_port}/metrics").
       to_return(status: 200, body: "hello world", headers: {})
 
-    status, headers, body = middleware.call("PATH_INFO" => '/metrics', "REMOTE_ADDR" => '192.168.1.1')
-    body = body.join
+    addresses = %w[127.1.2.3 192.168.1.2 10.0.1.2 172.16.9.8 172.19.1.2 172.20.9.8 172.29.1.2 172.30.9.8 172.31.1.2]
+    addresses.each do |ip|
+      status, headers, body = middleware.call("PATH_INFO" => '/metrics', "REMOTE_ADDR" => ip)
+      body = body.join
 
-    expect(status).to eq(200)
-    expect(headers["Content-Type"]).to eq('text/plain; charset=utf-8')
-    expect(body).to include('hello world')
+      expect(status).to eq(200)
+      expect(headers["Content-Type"]).to eq('text/plain; charset=utf-8')
+      expect(body).to include('hello world')
+    end
   end
 
   it "can proxy the dedicated port even with invalid regex" do


### PR DESCRIPTION
The regular expression to detect private IP addresses did not always
detect them successfully. Changed to use ruby's in-built
IPAddr.new(ip_address).private? method instead which does the same thing
but covers all cases.