### PR TITLE
FEATURE: Receive and export custom gauge metrics.

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -93,4 +93,9 @@ after_initialize do
     metric.job_name = worker.class.to_s
     $prometheus_client.send_json metric.to_h unless Rails.env.test?
   end
+
+  DiscourseEvent.on(:export_gauge_metric) do |name, description, value|
+    metric_h = DiscoursePrometheus::InternalMetric::Custom.create_gauge_hash(name, description, value)
+    $prometheus_client.send_json(metric_h) unless Rails.env.test?
+  end
 end


### PR DESCRIPTION
Other plugins can add custom gauge metrics by triggering the `export_gauge_metric` event. By adding the metric through an event, we don't need to add plugin-specific code behind an if statement.