### PR TITLE
FEATURE: Collect custom global metrics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # see: https://meta.discourse.org/t/prometheus-exporter-plugin-for-discourse/72666
+
+## Adding custom global collectors
+
+The global reporter can pick custom metrics added by other Discourse plugins. The metric needs to define a collect method, and the `name`, `labels`, `description`, `value`, and `type` attributes. See an example [here](https://github.com/discourse/discourse-antivirus/pull/15).

--- a/plugin.rb
+++ b/plugin.rb
@@ -31,6 +31,7 @@ require_relative("lib/middleware/metrics")
 
 GlobalSetting.add_default :prometheus_collector_port, 9405
 GlobalSetting.add_default :prometheus_trusted_ip_allowlist_regex, ''
+DiscoursePluginRegistry.define_filtered_register :global_collectors
 
 Rails.configuration.middleware.unshift DiscoursePrometheus::Middleware::Metrics
 

--- a/spec/support/null_metric.rb
+++ b/spec/support/null_metric.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module DiscoursePrometheus
+  class NullMetric < ::DiscoursePrometheus::InternalMetric::Custom
+    attribute :name , :labels, :description, :value, :type
+
+    def initialize
+      @name = 'null_metric'
+      @description = 'Testing'
+      @type = "Gauge"
+    end
+
+    def collect
+      @value = 1
+    end
+  end
+end


### PR DESCRIPTION
Other plugins can add custom global metrics by adding them to a DiscoursePluginRegistry filtered register.