### PR TITLE
DEV: Remove constant already initialized warning.

### DIFF
--- a/lib/reporter/web.rb
+++ b/lib/reporter/web.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 #
-require_dependency 'middleware/request_tracker'
+require 'middleware/request_tracker'
 
 class DiscoursePrometheus::Reporter::Web
 


### PR DESCRIPTION
`require_dependency` is only required in rare situations and should
really be considered internal to Rails. A simple `require` would suffice
here.