### PR TITLE
FEATURE: Label all timing metrics with logged_in boolean

### DIFF
--- a/lib/collector.rb
+++ b/lib/collector.rb
@@ -269,15 +269,14 @@ module ::DiscoursePrometheus
         labels[:action] = "other"
       end
 
+      labels[:logged_in] = metric.logged_in
+
       @http_duration_seconds.observe(metric.duration, labels)
       @http_sql_duration_seconds.observe(metric.sql_duration, labels)
       @http_redis_duration_seconds.observe(metric.redis_duration, labels)
       @http_net_duration_seconds.observe(metric.net_duration, labels)
       @http_queue_duration_seconds.observe(metric.queue_duration, labels)
-      @http_sql_calls_per_request.observe(
-        metric.sql_calls,
-        labels.merge(logged_in: metric.logged_in),
-      )
+      @http_sql_calls_per_request.observe(metric.sql_calls, labels)
 
       if cache = metric.cache
         if cache == "store"

--- a/spec/lib/collector_spec.rb
+++ b/spec/lib/collector_spec.rb
@@ -259,6 +259,7 @@ module DiscoursePrometheus
         net_duration: 5,
         controller: "list",
         action: "latest",
+        logged_in: true,
       )
 
       metrics << InternalMetric::Web.get(
@@ -269,7 +270,8 @@ module DiscoursePrometheus
         net_duration: 5,
         controller: "list",
         action: "latest",
-        cache: "true",
+        cache: true,
+        logged_in: false,
       )
 
       collector = Collector.new
@@ -286,6 +288,7 @@ module DiscoursePrometheus
             action: "latest",
             success: true,
             cache: false,
+            logged_in: true,
           } => {
             "count" => 1,
             "sum" => sum,
@@ -295,6 +298,7 @@ module DiscoursePrometheus
             action: "latest",
             success: false,
             cache: true,
+            logged_in: false,
           } => {
             "count" => 1,
             "sum" => sum,


### PR DESCRIPTION
All these timing metrics are highly affected by the anonymous cache. Tracking anon and regular users in the same metric can be somewhat misleading, because the site will appear to get faster during anonymous traffic spikes, while in reality it could be getting slower for the (arguably more important) logged-in users