### PR TITLE
FEATURE: Add message-bus redis metrics; deprecate master/slave names

### DIFF
--- a/lib/collector.rb
+++ b/lib/collector.rb
@@ -108,17 +108,32 @@ module ::DiscoursePrometheus
 
       global_metrics << Gauge.new(
         "redis_master_available",
-        "Whether or not we have an active connection to the master Redis",
+        "DEPRECATED: see redis_primary_available"
+      )
+
+      global_metrics << Gauge.new(
+        "redis_primary_available",
+        "Whether or not we have an active connection to the primary Redis",
       )
 
       global_metrics << Gauge.new(
         "redis_slave_available",
-        "Whether or not we have an active connection a Redis slave"
+        "DEPRECATED: see redis_replica_available"
+      )
+
+      global_metrics << Gauge.new(
+        "redis_replica_available",
+        "Whether or not we have an active connection to the replica Redis"
       )
 
       global_metrics << Gauge.new(
         "postgres_master_available",
-        "Whether or not we have an active connection to the master PostgreSQL"
+        "DEPRECATED: See postgres_primary_available"
+      )
+
+      global_metrics << Gauge.new(
+        "postgres_primary_available",
+        "Whether or not we have an active connection to the primary PostgreSQL"
       )
 
       global_metrics << Gauge.new(

--- a/spec/lib/internal_metric/global_spec.rb
+++ b/spec/lib/internal_metric/global_spec.rb
@@ -17,6 +17,12 @@ module DiscoursePrometheus::InternalMetric
       expect(metric.sidekiq_processes).not_to eq(nil)
       expect(metric.postgres_master_available).to eq(1)
       expect(metric.postgres_replica_available).to eq(nil)
+      expect(metric.redis_primary_available).to eq({
+        { type: "main" } => 1
+      })
+      expect(metric.redis_replica_available).to eq({
+        { type: "main" } => 0
+      })
     end
 
     it "can collect the version_info metric" do

--- a/spec/lib/reporter/global_spec.rb
+++ b/spec/lib/reporter/global_spec.rb
@@ -15,7 +15,7 @@ module DiscoursePrometheus
       collector = Reporter::Global.new(recycle_every: 2)
       metric = collector.collect.first
 
-      expect(metric.redis_slave_available).to eq(0)
+      expect(metric.redis_slave_available[{ type: 'main' }]).to eq(0)
 
       id = metric.object_id
 


### PR DESCRIPTION
- Adds a new 'type' label to the redis_master_available and redis_slave_available metrics. If a message-bus redis is configured, this will differentiate between the 'main' and 'message-bus' redis instances

- Updates names of Redis and Postgres metrics:
  `redis_master_available` -> `redis_primary_available`
  `redis_slave_available` -> `redis_replica_available`
  `postgres_master_available` -> `postgres_primary_available`

  Support for the old names is maintained for now with a deprecation notice in the metric description