### PR TITLE
FEATURE: add the scheduled_job_failures metric

### DIFF
--- a/lib/internal_metric/process.rb
+++ b/lib/internal_metric/process.rb
@@ -22,7 +22,7 @@ module DiscoursePrometheus::InternalMetric
       major_gc_count: "Major GC operations by process",
       minor_gc_count: "Minor GC operations by process",
       total_allocated_objects: "Total number of allocateds objects by process",
-      scheduled_job_failures: "Number of recurring scheduled jobs that failed in a process"
+      job_failures: "Number of scheduled and regular jobs that failed in a process"
     }
 
     attribute :type,
@@ -43,7 +43,7 @@ module DiscoursePrometheus::InternalMetric
       :active_record_connections_count,
       :active_record_failover_count,
       :redis_failover_count,
-      :scheduled_job_failures
+      :job_failures
 
     def initialize
       @active_record_connections_count = {}

--- a/lib/internal_metric/process.rb
+++ b/lib/internal_metric/process.rb
@@ -22,6 +22,7 @@ module DiscoursePrometheus::InternalMetric
       major_gc_count: "Major GC operations by process",
       minor_gc_count: "Minor GC operations by process",
       total_allocated_objects: "Total number of allocateds objects by process",
+      scheduled_job_failures: "Number of recurring scheduled jobs that failed in a process"
     }
 
     attribute :type,
@@ -41,7 +42,8 @@ module DiscoursePrometheus::InternalMetric
       :deferred_jobs_queued,
       :active_record_connections_count,
       :active_record_failover_count,
-      :redis_failover_count
+      :redis_failover_count,
+      :scheduled_job_failures
 
     def initialize
       @active_record_connections_count = {}

--- a/lib/reporter/process.rb
+++ b/lib/reporter/process.rb
@@ -52,7 +52,15 @@ module DiscoursePrometheus::Reporter
 
       if Discourse.respond_to?(:job_exception_stats)
         Discourse.job_exception_stats.each do |klass, count|
-          metric.job_failures[{ "job" => klass.to_s }] = count
+          key = { "job" => klass.to_s }
+          if klass.class == Class && klass < ::Jobs::Scheduled
+            key["family"] = "scheduled"
+          else
+            # this is a guess, but regular jobs simply inherit off
+            # Jobs::Base, so there is no easy way of finding out
+            key["family"] = "regular"
+          end
+          metric.job_failures[key] = count
         end
       end
     end

--- a/lib/reporter/process.rb
+++ b/lib/reporter/process.rb
@@ -54,7 +54,6 @@ module DiscoursePrometheus::Reporter
         Discourse.job_exception_stats.each do |klass, count|
           metric.job_failures[{ "job" => klass.to_s }] = count
         end
-        metric.job_failures = failures
       end
     end
 

--- a/lib/reporter/process.rb
+++ b/lib/reporter/process.rb
@@ -47,6 +47,16 @@ module DiscoursePrometheus::Reporter
 
     def collect_scheduler_stats(metric)
       metric.deferred_jobs_queued = Scheduler::Defer.length
+
+      if Discourse.respond_to?(:job_exception_stats)
+        failures = {}
+        Discourse.job_exception_stats.each do |klass, count|
+          failures[{ "job" => klass.to_s }] = count
+        end
+        metric.scheduled_job_failures = failures
+      else
+        metric.scheduled_job_failures = {}
+      end
     end
 
     def collect_process_stats(metric)

--- a/lib/reporter/process.rb
+++ b/lib/reporter/process.rb
@@ -48,12 +48,13 @@ module DiscoursePrometheus::Reporter
     def collect_scheduler_stats(metric)
       metric.deferred_jobs_queued = Scheduler::Defer.length
 
-      metric.scheduled_job_failures = {}
+      metric.job_failures = {}
 
       if Discourse.respond_to?(:job_exception_stats)
         Discourse.job_exception_stats.each do |klass, count|
-          metric.scheduled_job_failures[{ "job" => klass.to_s }] = count
+          metric.job_failures[{ "job" => klass.to_s }] = count
         end
+        metric.job_failures = failures
       end
     end
 

--- a/lib/reporter/process.rb
+++ b/lib/reporter/process.rb
@@ -48,14 +48,12 @@ module DiscoursePrometheus::Reporter
     def collect_scheduler_stats(metric)
       metric.deferred_jobs_queued = Scheduler::Defer.length
 
+      metric.scheduled_job_failures = {}
+
       if Discourse.respond_to?(:job_exception_stats)
-        failures = {}
         Discourse.job_exception_stats.each do |klass, count|
-          failures[{ "job" => klass.to_s }] = count
+          metric.scheduled_job_failures[{ "job" => klass.to_s }] = count
         end
-        metric.scheduled_job_failures = failures
-      else
-        metric.scheduled_job_failures = {}
       end
     end
 

--- a/spec/lib/collector_spec.rb
+++ b/spec/lib/collector_spec.rb
@@ -116,6 +116,7 @@ module DiscoursePrometheus
 
         expect(metric.data).to eq({
           {
+            "family" => "scheduled",
             type: "web",
             pid: Process.pid,
             "job" => "Jobs::ReindexSearch"

--- a/spec/lib/collector_spec.rb
+++ b/spec/lib/collector_spec.rb
@@ -83,6 +83,46 @@ module DiscoursePrometheus
       expect(ar.data[type: 'web', pid: Process.pid, status: "busy"]).to be > 0
     end
 
+    context "job_exception_stats" do
+      before do
+        Discourse.reset_job_exception_stats!
+      end
+
+      after do
+        Discourse.reset_job_exception_stats!
+      end
+
+      it "can collect job_exception_stats" do
+
+        # see MiniScheduler Manager which reports it like this
+        # https://github.com/discourse/mini_scheduler/blob/2b2c1c56b6e76f51108c2a305775469e24cf2b65/lib/mini_scheduler/manager.rb#L95
+        exception_context = {
+          message: "Running a scheduled job",
+          job: { "class" => Jobs::ReindexSearch }
+        }
+
+        2.times do
+          expect {
+            Discourse.handle_job_exception(StandardError.new, exception_context)
+          }.to raise_error(StandardError)
+        end
+
+        metric = Reporter::Process.new(:web).collect
+
+        collector = DiscoursePrometheus::Collector.new
+        collector.process(metric.to_json)
+
+        metric = collector.prometheus_metrics.find { |m| m.name == "job_failures" }
+
+        expect(metric.data).to eq({
+          {
+            type: "web",
+            pid: Process.pid,
+            "job" => "Jobs::ReindexSearch"
+          } => 2 })
+      end
+    end
+
     it "Can expire old metrics" do
       collector = Collector.new
 

--- a/spec/lib/reporter/process_spec.rb
+++ b/spec/lib/reporter/process_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'prometheus_exporter/server'
-require_relative '../../../lib/collector'
 
 module DiscoursePrometheus
   describe Reporter::Process do
@@ -51,23 +49,10 @@ module DiscoursePrometheus
         end
 
         metric = Reporter::Process.new(:web).collect
-        expect(metric.scheduled_job_failures).to eq({
+        expect(metric.job_failures).to eq({
           { "job" => "Jobs::ReindexSearch" } => 2
         })
-
-        collector = DiscoursePrometheus::Collector.new
-        collector.process(metric.to_json)
-
-        metric = collector.prometheus_metrics.find { |m| m.name == "scheduled_job_failures" }
-
-        expect(metric.data).to eq({
-          {
-            type: "web",
-            pid: Process.pid,
-            "job" => "Jobs::ReindexSearch"
-          } => 2 })
       end
-
     end
 
     it "can collect failover data" do

--- a/spec/lib/reporter/process_spec.rb
+++ b/spec/lib/reporter/process_spec.rb
@@ -50,7 +50,7 @@ module DiscoursePrometheus
 
         metric = Reporter::Process.new(:web).collect
         expect(metric.job_failures).to eq({
-          { "job" => "Jobs::ReindexSearch" } => 2
+          { "job" => "Jobs::ReindexSearch", "family" => "scheduled" } => 2
         })
       end
     end


### PR DESCRIPTION
This new metric allows monitoring of failed scheduled job runs

Previously we had no visibility outside of logs for this information
