### PR TITLE
FEATURE: Initialize metrics at 0 for all known jobs

### DIFF
--- a/lib/collector.rb
+++ b/lib/collector.rb
@@ -206,10 +206,10 @@ module ::DiscoursePrometheus
       }
       if metric.scheduled
         @scheduled_job_duration_seconds.observe(metric.duration, hash)
-        @scheduled_job_count.observe(1, hash)
+        @scheduled_job_count.observe(metric.count, hash)
       else
         @sidekiq_job_duration_seconds.observe(metric.duration, hash)
-        @sidekiq_job_count.observe(1, hash)
+        @sidekiq_job_count.observe(metric.count, hash)
       end
     end
 

--- a/lib/internal_metric/job.rb
+++ b/lib/internal_metric/job.rb
@@ -2,6 +2,6 @@
 
 module DiscoursePrometheus::InternalMetric
   class Job < Base
-    attribute :job_name, :scheduled, :duration
+    attribute :job_name, :scheduled, :duration, :count
   end
 end

--- a/lib/job_metric_initializer.rb
+++ b/lib/job_metric_initializer.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class ::DiscoursePrometheus::JobMetricInitializer
+  def self.initialize_scheduled_job_metrics
+    each_scheduled_job_metric do |metric|
+      $prometheus_client.send_json metric.to_h
+    end
+  end
+
+  def self.initialize_regular_job_metrics
+    each_regular_job_metric do |metric|
+      $prometheus_client.send_json metric.to_h
+    end
+  end
+
+  def self.each_regular_job_metric
+    # Enumerate all regular jobs and send a count=0 metric to the collector. This is not perfect - technically
+    # any class can be passed to Jobs.enqueue. Discourse tends to pass a string to `Jobs.enqueue`, which is then
+    # looked up from Jobs.constants, so this should cover the vast majority of cases
+    ::Jobs.constants.each do |const|
+      job_klass = ::Jobs.const_get(const)
+      next if job_klass.class != Class
+      next if job_klass == ::Jobs::Base
+
+      ancestors = job_klass.ancestors
+
+      if ancestors.include?(::Jobs::Base) && !ancestors.include?(::Jobs::Scheduled) && !ancestors.include?(::Jobs::Onceoff)
+        metric = DiscoursePrometheus::InternalMetric::Job.new
+        metric.scheduled = false
+        metric.duration = 0
+        metric.count = 0
+        metric.job_name = job_klass.name
+        yield metric
+      end
+    end
+  end
+
+  def self.each_scheduled_job_metric
+    # Enumerate all scheduled jobs and send a count=0 metric to the collector
+    # to initialize the metric
+    ::MiniScheduler::Manager.discover_schedules.each do |job_klass|
+      metric = DiscoursePrometheus::InternalMetric::Job.new
+      metric.scheduled = true
+      metric.duration = 0
+      metric.count = 0
+      metric.job_name = job_klass.name
+      yield metric
+    end
+  end
+end

--- a/spec/job_metric_initializer_spec.rb
+++ b/spec/job_metric_initializer_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe ::DiscoursePrometheus::JobMetricInitializer do
+  it "can enumerate regular jobs" do
+    metrics = []
+    DiscoursePrometheus::JobMetricInitializer.each_regular_job_metric { |m| metrics << m }
+    expect(metrics.all? { |m| m.count == 0 }).to eq(true)
+    expect(metrics.all? { |m| m.duration == 0 }).to eq(true)
+    expect(metrics.map(&:job_name)).to include("Jobs::RunHeartbeat")
+    expect(metrics.map(&:job_name)).not_to include("Jobs::Heartbeat")
+  end
+
+  it "can enumerate scheduled jobs" do
+    Jobs::Heartbeat # ensure class is loaded (in prod, classes are eager-loaded)
+
+    metrics = []
+    DiscoursePrometheus::JobMetricInitializer.each_scheduled_job_metric { |m| metrics << m }
+    expect(metrics.all? { |m| m.count == 0 }).to eq(true)
+    expect(metrics.all? { |m| m.duration == 0 }).to eq(true)
+    expect(metrics.all? { |m| m.scheduled == true }).to eq(true)
+    expect(metrics.map(&:job_name)).to include("Jobs::Heartbeat")
+    expect(metrics.map(&:job_name)).not_to include("Jobs::RunHeartbeat")
+  end
+end

--- a/spec/lib/collector_spec.rb
+++ b/spec/lib/collector_spec.rb
@@ -56,6 +56,7 @@ module DiscoursePrometheus
       metric.scheduled = true
       metric.job_name = "Bob"
       metric.duration = 1.778
+      metric.count = 1
 
       collector.process(metric.to_json)
       metrics = collector.prometheus_metrics

--- a/spec/lib/collector_spec.rb
+++ b/spec/lib/collector_spec.rb
@@ -67,6 +67,25 @@ module DiscoursePrometheus
       expect(count.data).to eq({ job_name: "Bob" } => 1)
     end
 
+    it "Can handle job initialization metrics" do
+      collector = Collector.new
+      metric = InternalMetric::Job.new
+
+      metric.scheduled = true
+      metric.job_name = "Bob"
+      metric.count = 0
+      metric.duration = 0
+
+      collector.process(metric.to_json)
+      metrics = collector.prometheus_metrics
+
+      duration = metrics.find { |m| m.name == "scheduled_job_duration_seconds" }
+      count = metrics.find { |m| m.name == "scheduled_job_count" }
+
+      expect(duration.data).to eq({ job_name: "Bob" } => 0)
+      expect(count.data).to eq({ job_name: "Bob" } => 0)
+    end
+
     it "Can handle process metrics" do
       skip("skipped because /proc does not exist on macOS") if RbConfig::CONFIG["arch"] =~ /darwin/
       collector = Collector.new

--- a/spec/lib/internal_metric/base_spec.rb
+++ b/spec/lib/internal_metric/base_spec.rb
@@ -10,11 +10,13 @@ module DiscoursePrometheus::InternalMetric
       job.job_name = "bob"
       job.scheduled = true
       job.duration = 100.1
+      job.count = 1
 
       expect(job.to_h).to eq(
         job_name: "bob",
         scheduled: true,
         duration: 100.1,
+        count: 1,
         _type: "Job"
       )
     end


### PR DESCRIPTION
Giving metrics a baseline of 0 ensures that prometheus functions like `increase()` function correctly.