### PR TITLE
FEATURE: Add `content_type` label to web performance metrics

### DIFF
--- a/lib/internal_metric/web.rb
+++ b/lib/internal_metric/web.rb
@@ -14,6 +14,7 @@ module DiscoursePrometheus::InternalMetric
       mobile
       tracked
       json
+      html
       admin_api
       user_api
       forced_anon
@@ -96,6 +97,9 @@ module DiscoursePrometheus::InternalMetric
       metric.json =
         env["PATH_INFO"].to_s.ends_with?(".json") ||
           env["HTTP_ACCEPT"].to_s.include?("application/json")
+
+      metric.html =
+        env["PATH_INFO"].to_s.ends_with?(".html") || env["HTTP_ACCEPT"].to_s.include?("text/html")
 
       metric.ajax = env["HTTP_X_REQUESTED_WITH"] == "XMLHttpRequest"
       metric.forced_anon = !!env["DISCOURSE_FORCE_ANON"]

--- a/spec/lib/collector_spec.rb
+++ b/spec/lib/collector_spec.rb
@@ -257,6 +257,7 @@ module DiscoursePrometheus
         sql_duration: 1,
         redis_duration: 3,
         net_duration: 5,
+        json: true,
         controller: "list",
         action: "latest",
         logged_in: true,
@@ -272,6 +273,7 @@ module DiscoursePrometheus
         action: "latest",
         cache: true,
         logged_in: false,
+        html: true,
       )
 
       collector = Collector.new
@@ -289,6 +291,7 @@ module DiscoursePrometheus
             success: true,
             cache: false,
             logged_in: true,
+            content_type: "json",
           } => {
             "count" => 1,
             "sum" => sum,
@@ -299,6 +302,7 @@ module DiscoursePrometheus
             success: false,
             cache: true,
             logged_in: false,
+            content_type: "html",
           } => {
             "count" => 1,
             "sum" => sum,


### PR DESCRIPTION
For now, `content_type` label can either be `json`, `html` or `other` to limit the cardinality of the metrics.