### PR TITLE
DEV: Introduce `http_gc_duration_seconds`, `http_gc_(major|minor)_count` metrics

### DIFF
--- a/lib/internal_metric/web.rb
+++ b/lib/internal_metric/web.rb
@@ -2,9 +2,9 @@
 
 module DiscoursePrometheus::InternalMetric
   class Web < Base
-    FLOAT_ATTRS = %w[duration sql_duration net_duration redis_duration queue_duration]
+    FLOAT_ATTRS = %w[duration sql_duration net_duration redis_duration queue_duration gc_duration]
 
-    INT_ATTRS = %w[sql_calls redis_calls net_calls status_code]
+    INT_ATTRS = %w[sql_calls redis_calls net_calls status_code gc_major_count gc_minor_count]
 
     BOOL_ATTRS = %w[
       ajax
@@ -81,6 +81,12 @@ module DiscoursePrometheus::InternalMetric
         if net = timing[:net]
           metric.net_duration = net[:duration]
           metric.net_calls = net[:calls]
+        end
+
+        if gc = timing[:gc]
+          metric.gc_duration = gc[:time]
+          metric.gc_major_count = gc[:major_count]
+          metric.gc_minor_count = gc[:minor_count]
         end
       end
 

--- a/spec/lib/collector_spec.rb
+++ b/spec/lib/collector_spec.rb
@@ -257,6 +257,9 @@ module DiscoursePrometheus
         sql_duration: 1,
         redis_duration: 2,
         net_duration: 3,
+        gc_duration: 4,
+        gc_major_count: 5,
+        gc_minor_count: 6,
         json: true,
         controller: "list",
         action: "latest",
@@ -269,6 +272,9 @@ module DiscoursePrometheus
         sql_duration: 1,
         redis_duration: 2,
         net_duration: 3,
+        gc_duration: 4,
+        gc_major_count: 5,
+        gc_minor_count: 6,
         controller: "list",
         action: "latest",
         cache: true,
@@ -316,7 +322,50 @@ module DiscoursePrometheus
         ["http_sql_duration_seconds", 1.0],
         ["http_redis_duration_seconds", 2.0],
         ["http_net_duration_seconds", 3.0],
+        ["http_gc_duration_seconds", 4.0],
       ].each { |metric_name, sum| assert_metric.call(metric_name, sum) }
+
+      expect(exported.find { |metric| metric.name == "http_gc_major_count" }.to_h).to eq(
+        {
+          controller: "list",
+          action: "latest",
+          success: true,
+          cache: false,
+          logged_in: true,
+          content_type: "json",
+        } =>
+          5,
+        {
+          controller: "list",
+          action: "latest",
+          success: false,
+          cache: true,
+          logged_in: false,
+          content_type: "html",
+        } =>
+          5,
+      )
+
+      expect(exported.find { |metric| metric.name == "http_gc_minor_count" }.to_h).to eq(
+        {
+          controller: "list",
+          action: "latest",
+          success: true,
+          cache: false,
+          logged_in: true,
+          content_type: "json",
+        } =>
+          6,
+        {
+          controller: "list",
+          action: "latest",
+          success: false,
+          cache: true,
+          logged_in: false,
+          content_type: "html",
+        } =>
+          6,
+      )
     end
   end
 end

--- a/spec/lib/internal_metric/web_spec.rb
+++ b/spec/lib/internal_metric/web_spec.rb
@@ -127,6 +127,11 @@ module DiscoursePrometheus::InternalMetric
               duration: 0.3,
               calls: 6,
             },
+            gc: {
+              time: 0.4,
+              major_count: 7,
+              minor_count: 8,
+            },
           },
         }
 
@@ -138,6 +143,10 @@ module DiscoursePrometheus::InternalMetric
 
         expect(metric.sql_calls).to eq(5)
         expect(metric.redis_calls).to eq(6)
+
+        expect(metric.gc_duration).to eq(0.4)
+        expect(metric.gc_major_count).to eq(7)
+        expect(metric.gc_minor_count).to eq(8)
       end
     end
   end


### PR DESCRIPTION
Why this change?

These metrics being introduced will allow us to understand the impact
that Ruby's GC has during a request and allows us to tune our GC in
production.