### PR TITLE
FIX: Exclude gc duration from application duration metric

### DIFF
--- a/lib/collector.rb
+++ b/lib/collector.rb
@@ -313,6 +313,7 @@ module ::DiscoursePrometheus
         application_duration -= metric.sql_duration if metric.sql_duration
         application_duration -= metric.redis_duration if metric.redis_duration
         application_duration -= metric.net_duration if metric.net_duration
+        application_duration -= metric.gc_duration if metric.gc_duration
         @http_application_duration_seconds.observe(application_duration, labels)
       end
 

--- a/spec/lib/collector_spec.rb
+++ b/spec/lib/collector_spec.rb
@@ -253,7 +253,7 @@ module DiscoursePrometheus
 
       metrics << InternalMetric::Web.get(
         status_code: 200,
-        duration: 10,
+        duration: 14,
         sql_duration: 1,
         redis_duration: 2,
         net_duration: 3,
@@ -268,7 +268,7 @@ module DiscoursePrometheus
 
       metrics << InternalMetric::Web.get(
         status_code: 302,
-        duration: 10,
+        duration: 14,
         sql_duration: 1,
         redis_duration: 2,
         net_duration: 3,
@@ -317,7 +317,7 @@ module DiscoursePrometheus
       }
 
       [
-        ["http_duration_seconds", 10.0],
+        ["http_duration_seconds", 14.0],
         ["http_application_duration_seconds", 4.0],
         ["http_sql_duration_seconds", 1.0],
         ["http_redis_duration_seconds", 2.0],


### PR DESCRIPTION
Excluding gc duration from application duration metric allows us to
stack the various duration graphs to make up the total duration of a
request.