### PR TITLE
FEATURE: Instrument reason for the trigger of last major GC

### DIFF
--- a/lib/internal_metric/process.rb
+++ b/lib/internal_metric/process.rb
@@ -3,6 +3,7 @@
 module DiscoursePrometheus::InternalMetric
   class Process < Base
     GAUGES = {
+      gc_major_by: "Reason the last major GC was triggered",
       heap_free_slots: "Free ruby heap slots",
       heap_live_slots: "Used ruby heap slots",
       v8_heap_size: "Total JavaScript V8 heap size (bytes)",
@@ -26,6 +27,7 @@ module DiscoursePrometheus::InternalMetric
     }
 
     attribute :type,
+              :gc_major_by,
               :heap_free_slots,
               :heap_live_slots,
               :major_gc_count,
@@ -47,6 +49,7 @@ module DiscoursePrometheus::InternalMetric
 
     def initialize
       @active_record_connections_count = {}
+      @gc_major_by = {}
     end
   end
 end

--- a/lib/reporter/process.rb
+++ b/lib/reporter/process.rb
@@ -88,6 +88,12 @@ module DiscoursePrometheus::Reporter
       metric.heap_free_slots = stat[:heap_free_slots]
       metric.major_gc_count = stat[:major_gc_count]
       metric.minor_gc_count = stat[:minor_gc_count]
+
+      if major_by = GC.latest_gc_info(:major_by)
+        metric.gc_major_by[major_by] ||= 0
+        metric.gc_major_by[major_by] += 1
+      end
+
       metric.total_allocated_objects = stat[:total_allocated_objects]
     end
 

--- a/spec/lib/reporter/process_spec.rb
+++ b/spec/lib/reporter/process_spec.rb
@@ -15,9 +15,12 @@ module DiscoursePrometheus
       ctx = MiniRacer::Context.new
       ctx.eval("")
 
+      GC.expects(:latest_gc_info).with(:major_by).returns(:nofree)
+
       metric = Reporter::Process.new(:web).collect
 
       expect(metric.type).to eq("web")
+      expect(metric.gc_major_by).to eq({ nofree: 1 })
 
       check_for(
         metric,


### PR DESCRIPTION
Why this change?

`GC.latest_gc_info(:major_by)` returns the reason that triggered the
last major GC run. This information is useful when doing GC tuning since
it will give us an idea on what to tune in order to have the greatest
impact.