### PR TITLE
FIX: postgres_highest_sequence naming

### DIFF
--- a/lib/collector.rb
+++ b/lib/collector.rb
@@ -181,7 +181,7 @@ module ::DiscoursePrometheus
       )
 
       global_metrics << Gauge.new(
-        "pg_highest_seq",
+        "postgres_highest_sequence",
         "The highest last_value from the pg_sequences table",
       )
 


### PR DESCRIPTION
The gauge was supposed to be renamed from pg_highest_seq to postgres_highest_sequence as part of the PR, but one place was missed

Followup to 44f22c2cb1f9b450b1f21ddba5c0bad62235e020