### PR TITLE
PERF: Avoid hammering the database with pg sequence check queries

### DIFF
--- a/lib/internal_metric/global.rb
+++ b/lib/internal_metric/global.rb
@@ -354,7 +354,7 @@ module DiscoursePrometheus::InternalMetric
         return @@postgres_highest_sequence_cache
       end
 
-      @@postgres_highest_sequence_last_check = Time.now
+      @@postgres_highest_sequence_last_check = Time.now.to_i
 
       result = {}
 

--- a/spec/lib/internal_metric/global_spec.rb
+++ b/spec/lib/internal_metric/global_spec.rb
@@ -113,13 +113,15 @@ module DiscoursePrometheus::InternalMetric
       end
     end
 
-    it "can collect pg_seq metric" do
-      3.times { Fabricate(:user) }
-
+    it "can collect pg_seq metric and caches the sequence" do
       metric.collect
 
       expect(metric.postgres_highest_sequence).to be_a_kind_of(Hash)
-      expect(metric.postgres_highest_sequence[{ db: "default" }]).to be > 3
+      expect(metric.postgres_highest_sequence[{ db: "default" }]).to be_present
+
+      expect do metric.collect end.not_to change {
+        metric.class.class_variable_get(:@@postgres_highest_sequence_last_check)
+      }
     end
   end
 end


### PR DESCRIPTION
Why this change?

In `Discourse::Prometheus::InternalMetric#calc_postgres_highest_sequence`, it was initially written such that
we will only query the database once every 60 seconds by setting the `postgres_highest_sequence_last_check`
class variable. However, there is a subtle bug in Rails where we were
storing a `Time` object in `@@postgres_highest_sequence_last_check` and
then subsequently using it to compare against an `Integer` which ends up
always evaluating to `false`.

```
[3] pry(main)> now = Time.now
=> 2024-01-25 06:01:07.44213925 +0800
[4] pry(main)> now >= Time.now.to_i - 60
=> false
[5] pry(main)> now.to_i >= Time.now.to_i - 60
=> true
```

Due to this bug, we end up querying all the databases every time metrics
are collected (defaults to every 5 seconds) instead of only querying the
databases every 60 seconds which is what we want to reduce the load on
our databases.

The bug in Rails has been reported in https://github.com/rails/rails/issues/50868