### PR TITLE
FEATURE: Add `database` label to `active_record_connections_count`

### DIFF
--- a/lib/reporter/process.rb
+++ b/lib/reporter/process.rb
@@ -118,9 +118,11 @@ module DiscoursePrometheus::Reporter
       ObjectSpace.each_object(ActiveRecord::ConnectionAdapters::ConnectionPool) do |pool|
         if !pool.connections.nil?
           stat = pool.stat
+          database = pool.db_config.database.to_s
 
           %i[busy dead idle waiting].each do |status|
-            key = { status: status.to_s }
+            key = { status: status.to_s, database: database }
+
             metric.active_record_connections_count[key] ||= 0
             metric.active_record_connections_count[key] += stat[status]
           end

--- a/spec/lib/collector_spec.rb
+++ b/spec/lib/collector_spec.rb
@@ -99,7 +99,9 @@ module DiscoursePrometheus
 
       ar = metrics.find { |metric| metric.name == "active_record_connections_count" }
 
-      expect(ar.data[type: "web", pid: Process.pid, status: "busy"]).to be > 0
+      expect(
+        ar.data[type: "web", pid: Process.pid, status: "busy", database: "discourse_test"],
+      ).to be > 0
     end
 
     describe "job_exception_stats" do

--- a/spec/lib/reporter/process_spec.rb
+++ b/spec/lib/reporter/process_spec.rb
@@ -38,6 +38,27 @@ module DiscoursePrometheus
       )
     end
 
+    describe "active_record_connections_count metric" do
+      it "can collect active_record_connections_count" do
+        metric = Reporter::Process.new(:web).collect
+
+        expect(
+          metric.active_record_connections_count[{ database: "discourse_test", status: "busy" }],
+        ).to be_present
+
+        expect(
+          metric.active_record_connections_count[{ database: "discourse_test", status: "idle" }],
+        ).to be_present
+
+        expect(
+          metric.active_record_connections_count[{ database: "discourse_test", status: "dead" }],
+        ).to be_present
+        expect(
+          metric.active_record_connections_count[{ database: "discourse_test", status: "waiting" }],
+        ).to be_present
+      end
+    end
+
     describe "job_exception_stats" do
       before { Discourse.reset_job_exception_stats! }
 


### PR DESCRIPTION
Why this change?

Prior to this change, the `active_record_connections_count` metric is
simply a sum of all the connections for all the connection pools.
However, this metric is not helpful in a multisite environment where
there are multiple connection pools and when we need to figure out which
connection pool is holding on to a large amount of connections.