### PR TITLE
DEV: Fix failing test by not hardcoding database name

### DIFF
--- a/spec/lib/collector_spec.rb
+++ b/spec/lib/collector_spec.rb
@@ -100,7 +100,12 @@ module DiscoursePrometheus
       ar = metrics.find { |metric| metric.name == "active_record_connections_count" }
 
       expect(
-        ar.data[type: "web", pid: Process.pid, status: "busy", database: "discourse_test"],
+        ar.data[
+          type: "web",
+          pid: Process.pid,
+          status: "busy",
+          database: ActiveRecord::Base.connection_pool.db_config.database
+        ],
       ).to be > 0
     end
 

--- a/spec/lib/reporter/process_spec.rb
+++ b/spec/lib/reporter/process_spec.rb
@@ -42,19 +42,21 @@ module DiscoursePrometheus
       it "can collect active_record_connections_count" do
         metric = Reporter::Process.new(:web).collect
 
+        database = ActiveRecord::Base.connection_pool.db_config.database
+
         expect(
-          metric.active_record_connections_count[{ database: "discourse_test", status: "busy" }],
+          metric.active_record_connections_count[{ database: database, status: "busy" }],
         ).to be_present
 
         expect(
-          metric.active_record_connections_count[{ database: "discourse_test", status: "idle" }],
+          metric.active_record_connections_count[{ database: database, status: "idle" }],
         ).to be_present
 
         expect(
-          metric.active_record_connections_count[{ database: "discourse_test", status: "dead" }],
+          metric.active_record_connections_count[{ database: database, status: "dead" }],
         ).to be_present
         expect(
-          metric.active_record_connections_count[{ database: "discourse_test", status: "waiting" }],
+          metric.active_record_connections_count[{ database: database, status: "waiting" }],
         ).to be_present
       end
     end


### PR DESCRIPTION
The database name may not always be `discourse_test` depending on how
the tests are ran. For example, it could be `discourse_test_1` when ran
using `turbo_rspec`