### PR TITLE
Revert adding database label to AR connections metric

### DIFF
--- a/lib/reporter/process.rb
+++ b/lib/reporter/process.rb
@@ -118,11 +118,9 @@ module DiscoursePrometheus::Reporter
       ObjectSpace.each_object(ActiveRecord::ConnectionAdapters::ConnectionPool) do |pool|
         if !pool.connections.nil?
           stat = pool.stat
-          database = pool.db_config.database.to_s
 
           %i[busy dead idle waiting].each do |status|
-            key = { status: status.to_s, database: database }
-
+            key = { status: status.to_s }
             metric.active_record_connections_count[key] ||= 0
             metric.active_record_connections_count[key] += stat[status]
           end

--- a/spec/lib/collector_spec.rb
+++ b/spec/lib/collector_spec.rb
@@ -99,14 +99,7 @@ module DiscoursePrometheus
 
       ar = metrics.find { |metric| metric.name == "active_record_connections_count" }
 
-      expect(
-        ar.data[
-          type: "web",
-          pid: Process.pid,
-          status: "busy",
-          database: ActiveRecord::Base.connection_pool.db_config.database
-        ],
-      ).to be > 0
+      expect(ar.data[type: "web", pid: Process.pid, status: "busy"]).to be > 0
     end
 
     describe "job_exception_stats" do

--- a/spec/lib/reporter/process_spec.rb
+++ b/spec/lib/reporter/process_spec.rb
@@ -38,29 +38,6 @@ module DiscoursePrometheus
       )
     end
 
-    describe "active_record_connections_count metric" do
-      it "can collect active_record_connections_count" do
-        metric = Reporter::Process.new(:web).collect
-
-        database = ActiveRecord::Base.connection_pool.db_config.database
-
-        expect(
-          metric.active_record_connections_count[{ database: database, status: "busy" }],
-        ).to be_present
-
-        expect(
-          metric.active_record_connections_count[{ database: database, status: "idle" }],
-        ).to be_present
-
-        expect(
-          metric.active_record_connections_count[{ database: database, status: "dead" }],
-        ).to be_present
-        expect(
-          metric.active_record_connections_count[{ database: database, status: "waiting" }],
-        ).to be_present
-      end
-    end
-
     describe "job_exception_stats" do
       before { Discourse.reset_job_exception_stats! }
 


### PR DESCRIPTION
This reverts commit 81abe649b79e90cca8988cffc0a373b649493621 and e7692a8d8f0c2cb20f86c26ba9f6081b47248a0b.

Adding the database labels caused the cardinality of the data set to
explode making metrics query time out.