### PR TITLE
DEV: Add compatibility with Rails 7.2

### DIFF
--- a/lib/internal_metric/global.rb
+++ b/lib/internal_metric/global.rb
@@ -210,7 +210,7 @@ module DiscoursePrometheus::InternalMetric
         end
       end
 
-      connection = ActiveRecord::Base.postgresql_connection(config)
+      connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(config)
       connection.tap(&:verify!).active? ? 1 : 0
     rescue StandardError
       0


### PR DESCRIPTION
Because of that [commit](https://github.com/rails/rails/commit/009c7e74117690f0dbe200188a929b345c9306c1), the `ActiveRecord::Base.postgresql_connection` method doesn’t exist anymore.

This PR addresses that issue by using what is now done in Rails: `ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new`.
