### PR TITLE
DEV: bump webrick to 1.8.2

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -10,6 +10,7 @@
 module ::DiscoursePrometheus
 end
 
+gem "webrick", "1.8.2"
 gem "prometheus_exporter", "2.0.6"
 
 require "prometheus_exporter/client"


### PR DESCRIPTION
Core has moved to webrick 1.8.2.

https://github.com/discourse/discourse/commit/0078f0973e90546fa73d2cb34bf8a53f80fd8f96

Follow-up to: 938680e4989bfaca4a35025fe75cf37866a0a4b2.