### PR TITLE
DEV: Add compatibility with Rails 7.2+

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -10,9 +10,9 @@
 module ::DiscoursePrometheus
 end
 
-gem "webrick", "1.8.2"
 gem "prometheus_exporter", "2.0.6"
 
+require "webrick"
 require "prometheus_exporter/client"
 
 require_relative("lib/internal_metric/base")


### PR DESCRIPTION
Webrick is provided by core, so we should not require a specific version here. (1.8.2 for main, Rails 7.2 will provide 1.9.0)