### PR TITLE
revert sequence metric changes

### DIFF
--- a/lib/internal_metric/global.rb
+++ b/lib/internal_metric/global.rb
@@ -368,25 +368,10 @@ module DiscoursePrometheus::InternalMetric
 
       RailsMultisite::ConnectionManagement.each_connection do |db|
         result[{ db: db }] = DB.query_single(<<~SQL)[0]
-          WITH columns_and_sequences AS (
-            SELECT table_name,
-                   column_name,
-                   information_schema.columns.data_type column_type,
-                   pg_sequences.data_type::text sequence_type,
-                   COALESCE(last_value, 0) last_value
-            FROM information_schema.columns
-            JOIN pg_sequences ON sequencename = REPLACE(REPLACE(column_default, 'nextval(''', ''), '''::regclass)', '')
-            WHERE information_schema.columns.table_schema = 'public'
-          )
-          SELECT MAX(last_value)
-          FROM columns_and_sequences
-          WHERE column_type = 'integer' OR
-                -- The column and sequence types should match, but this is just an extra check.
-                sequence_type = 'integer' OR
-                -- The `id` column of these tables is a `bigint`, but the foreign key columns are usually integers.
-                -- These columns will be migrated in the future.
-                -- See https://github.com/discourse/discourse/blob/6e1aeb1f504f469ceed189c24d43a7a99b8970c7/spec/rails_helper.rb#L480-L490
-                table_name IN ('reviewables', 'flags', 'sidebar_sections')
+          SELECT last_value
+          FROM pg_sequences
+          ORDER BY last_value DESC NULLS LAST
+          LIMIT 1
         SQL
       end
 

--- a/lib/internal_metric/global.rb
+++ b/lib/internal_metric/global.rb
@@ -353,7 +353,7 @@ module DiscoursePrometheus::InternalMetric
       stats
     end
 
-    PG_HIGHEST_SEQUENCE_CHECK_SECONDS = 21_600 #every six hours until query is faster
+    PG_HIGHEST_SEQUENCE_CHECK_SECONDS = 60
 
     def calc_postgres_highest_sequence
       @@postgres_highest_sequence_last_check ||= 0

--- a/spec/lib/internal_metric/global_spec.rb
+++ b/spec/lib/internal_metric/global_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe DiscoursePrometheus::InternalMetric::Global do
     expect(metric.postgres_highest_sequence).to be_a_kind_of(Hash)
     expect(metric.postgres_highest_sequence[{ db: "default" }]).to be_present
 
-    expect { metric.collect }.not_to change {
+    expect do metric.collect end.not_to change {
       metric.class.class_variable_get(:@@postgres_highest_sequence_last_check)
     }
   end


### PR DESCRIPTION
- **Revert "FIX: Increase interval for sequence check now that it is a slower check (#118)"**
- **Revert "FEATURE: Tweak `postgres_highest_sequence` only for int columns (#98)"**
