### PR TITLE
FEATURE: Tweak `postgres_highest_sequence` only for int columns

### DIFF
--- a/app/jobs/scheduled/update_stats.rb
+++ b/app/jobs/scheduled/update_stats.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Jobs
+  class UpdateStats < ::Jobs::Scheduled
+    every 1.hour
+
+    def execute(args = {})
+      postgres_highest_sequence = DB.query_single(<<~SQL)[0]
+          WITH columns AS MATERIALIZED (
+            SELECT table_name,
+                  column_name,
+                  data_type column_type,
+                  REPLACE(REPLACE(column_default, 'nextval(''', ''), '''::regclass)', '') sequence_name
+            FROM information_schema.columns
+            WHERE table_schema = 'public' AND column_default LIKE '%nextval(''%'
+          ), sequences AS MATERIALIZED (
+            SELECT sequencename sequence_name,
+                  data_type::text sequence_type,
+                  COALESCE(last_value, 0) last_value
+            FROM pg_sequences
+          )
+          SELECT MAX(last_value)
+          FROM columns
+          JOIN sequences ON sequences.sequence_name = columns.sequence_name
+          WHERE columns.column_type = 'integer' OR
+                -- The column and sequence types should match, but this is just an extra check.
+                sequences.sequence_type = 'integer' OR
+                -- The `id` column of these tables is a `bigint`, but the foreign key columns are usually integers.
+                -- These columns will be migrated in the future.
+                -- See https://github.com/discourse/discourse/blob/6e1aeb1f504f469ceed189c24d43a7a99b8970c7/spec/rails_helper.rb#L480-L490
+                table_name IN ('reviewables', 'flags', 'sidebar_sections')
+        SQL
+
+      Discourse.stats.set("postgres_highest_sequence", postgres_highest_sequence)
+    end
+  end
+end

--- a/lib/internal_metric/global.rb
+++ b/lib/internal_metric/global.rb
@@ -368,10 +368,29 @@ module DiscoursePrometheus::InternalMetric
 
       RailsMultisite::ConnectionManagement.each_connection do |db|
         result[{ db: db }] = DB.query_single(<<~SQL)[0]
-          SELECT last_value
-          FROM pg_sequences
-          ORDER BY last_value DESC NULLS LAST
-          LIMIT 1
+          WITH columns AS MATERIALIZED (
+            SELECT table_name,
+                   column_name,
+                   data_type column_type,
+                   REPLACE(REPLACE(column_default, 'nextval(''', ''), '''::regclass)', '') sequence_name
+            FROM information_schema.columns
+            WHERE table_schema = 'public' AND column_default LIKE '%nextval(''%'
+          ), sequences AS MATERIALIZED (
+            SELECT sequencename sequence_name,
+                   data_type::text sequence_type,
+                   COALESCE(last_value, 0) last_value
+            FROM pg_sequences
+          )
+          SELECT MAX(last_value)
+          FROM columns
+          JOIN sequences ON sequences.sequence_name = columns.sequence_name
+          WHERE columns.column_type = 'integer' OR
+                -- The column and sequence types should match, but this is just an extra check.
+                sequences.sequence_type = 'integer' OR
+                -- The `id` column of these tables is a `bigint`, but the foreign key columns are usually integers.
+                -- These columns will be migrated in the future.
+                -- See https://github.com/discourse/discourse/blob/6e1aeb1f504f469ceed189c24d43a7a99b8970c7/spec/rails_helper.rb#L480-L490
+                table_name IN ('reviewables', 'flags', 'sidebar_sections')
         SQL
       end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -41,6 +41,8 @@ DiscoursePluginRegistry.define_filtered_register :global_collectors
 Rails.configuration.middleware.unshift DiscoursePrometheus::Middleware::Metrics
 
 after_initialize do
+  require_relative("app/jobs/scheduled/update_stats")
+
   $prometheus_client =
     PrometheusExporter::Client.new(host: "localhost", port: GlobalSetting.prometheus_collector_port)
 

--- a/spec/lib/internal_metric/global_spec.rb
+++ b/spec/lib/internal_metric/global_spec.rb
@@ -104,14 +104,12 @@ RSpec.describe DiscoursePrometheus::InternalMetric::Global do
     end
   end
 
-  it "collects pg_seq metric and caches the sequence" do
+  it "collects postgres_highest_sequence metric" do
+    Jobs::UpdateStats.new.execute
+
     metric.collect
 
     expect(metric.postgres_highest_sequence).to be_a_kind_of(Hash)
     expect(metric.postgres_highest_sequence[{ db: "default" }]).to be_present
-
-    expect do metric.collect end.not_to change {
-      metric.class.class_variable_get(:@@postgres_highest_sequence_last_check)
-    }
   end
 end


### PR DESCRIPTION
This is a reimplementation of commit 1015d9e3 and a revert of commit 98b8d44b.

The original implementation was using the REPLACE function in the filter, which was causing the query to be very slow. For some databases, the old query ran in ~6 seconds, while this optimized one runs in ~30ms.

Unfortunately, it is still slower than the previous one that executed in ~2ms.