### PR TITLE
DEV: Drop `webrick` gem since it is already available in Discourse core

### DIFF
--- a/lib/collector_demon.rb
+++ b/lib/collector_demon.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 #
 require_dependency "demon/base"
+require "webrick"
 
 class DiscoursePrometheus::CollectorDemon < ::Demon::Base
   def self.prefix

--- a/plugin.rb
+++ b/plugin.rb
@@ -10,7 +10,6 @@
 module ::DiscoursePrometheus
 end
 
-gem "webrick", "1.9.1"
 gem "prometheus_exporter", "2.0.6"
 
 require "prometheus_exporter/client"


### PR DESCRIPTION
This makes upgrading the webrick gem in Discourse core much easier since
we will no longer have conflicting gem versions.
