### PR TITLE
DEV: add tmp_dir_available_bytes metric

### DIFF
--- a/lib/collector.rb
+++ b/lib/collector.rb
@@ -185,6 +185,11 @@ module ::DiscoursePrometheus
         "The highest last_value from the pg_sequences table",
       )
 
+      global_metrics << Gauge.new(
+        "tmp_dir_available_bytes",
+        "Available space in /tmp directory (bytes)",
+      )
+
       @global_metrics = global_metrics
     end
 

--- a/spec/lib/internal_metric/global_spec.rb
+++ b/spec/lib/internal_metric/global_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe DiscoursePrometheus::InternalMetric::Global do
     expect(metric.postgres_replica_available).to eq(nil)
     expect(metric.redis_primary_available).to eq({ { type: "main" } => 1 })
     expect(metric.redis_replica_available).to eq({ { type: "main" } => 0 })
+    expect(metric.tmp_dir_available_bytes).to be > 0
   end
 
   it "collects the version_info metric" do


### PR DESCRIPTION
The Discourse application and plugins utilise the `/tmp` directory for
local storage during request and job processing. If the directory has no
space remaining, attempting to create files will fail.

Exposing the amount of space available in the directory is useful in
environments where this directory is limited in size.

See t/111786.