### PR TITLE
FEATURE: Add `process_cpu_seconds_total` metric

### DIFF
--- a/lib/internal_metric/process.rb
+++ b/lib/internal_metric/process.rb
@@ -22,8 +22,9 @@ module DiscoursePrometheus::InternalMetric
       gc_major_by: "Reason the last major GC was triggered",
       major_gc_count: "Major GC operations by process",
       minor_gc_count: "Minor GC operations by process",
-      total_allocated_objects: "Total number of allocateds objects by process",
+      total_allocated_objects: "Total number of allocated objects by process",
       job_failures: "Number of scheduled and regular jobs that failed in a process",
+      process_cpu_seconds_total: "Total CPU time used by the process",
     }
 
     attribute :type,
@@ -45,7 +46,8 @@ module DiscoursePrometheus::InternalMetric
               :active_record_connections_count,
               :active_record_failover_count,
               :redis_failover_count,
-              :job_failures
+              :job_failures,
+              :process_cpu_seconds_total
 
     def initialize
       @active_record_connections_count = {}

--- a/lib/reporter/process.rb
+++ b/lib/reporter/process.rb
@@ -56,6 +56,10 @@ module DiscoursePrometheus::Reporter
       end
     end
 
+    def process_cpu_seconds_total
+      ::Process.clock_gettime(::Process::CLOCK_PROCESS_CPUTIME_ID)
+    end
+
     def collect_scheduler_stats(metric)
       metric.deferred_jobs_queued = Scheduler::Defer.length
 
@@ -80,6 +84,7 @@ module DiscoursePrometheus::Reporter
       metric.pid = pid
       metric.rss = rss
       metric.thread_count = Thread.list.count
+      metric.process_cpu_seconds_total = process_cpu_seconds_total
     end
 
     def collect_gc_stats(metric)

--- a/spec/lib/reporter/process_spec.rb
+++ b/spec/lib/reporter/process_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe DiscoursePrometheus::Reporter::Process do
     expect(metric.v8_physical_size).to be > 0
     expect(metric.pid).to be > 0
     expect(metric.thread_count).to be > 0
+    expect(metric.process_cpu_seconds_total).to be > 0
 
     # macos does not support these metrics
     expect(metric.rss).to be > 0 unless RbConfig::CONFIG["arch"] =~ /darwin/


### PR DESCRIPTION
This allows us to track the CPU usage time for each process as part of
application performance monitoring efforts.
