### PR TITLE
FEATURE: Add `sidekiq_queue_latency_seconds` metric

### DIFF
--- a/lib/collector.rb
+++ b/lib/collector.rb
@@ -159,6 +159,11 @@ module ::DiscoursePrometheus
       global_metrics << Gauge.new("sidekiq_workers", "Total number of active sidekiq workers")
 
       global_metrics << Gauge.new(
+        "sidekiq_queue_latency_seconds",
+        "Latency in seconds for each Sidekiq queue",
+      )
+
+      global_metrics << Gauge.new(
         "sidekiq_jobs_stuck",
         "Number of sidekiq jobs which have been running for more than #{InternalMetric::Global::STUCK_SIDEKIQ_JOB_MINUTES} minutes",
       )

--- a/lib/internal_metric/global.rb
+++ b/lib/internal_metric/global.rb
@@ -23,6 +23,7 @@ module DiscoursePrometheus::InternalMetric
               :sidekiq_paused,
               :sidekiq_workers,
               :sidekiq_jobs_stuck,
+              :sidekiq_queue_latency_seconds,
               :scheduled_jobs_stuck,
               :missing_s3_uploads,
               :version_info,
@@ -131,6 +132,13 @@ module DiscoursePrometheus::InternalMetric
             stats[{ queue: queue_name }] = queue_count
           end
 
+          stats
+        end
+
+      @sidekiq_queue_latency_seconds =
+        begin
+          stats = {}
+          Sidekiq::Queue.all.each { |queue| stats[{ queue: queue.name }] = queue.latency }
           stats
         end
 

--- a/spec/lib/internal_metric/global_spec.rb
+++ b/spec/lib/internal_metric/global_spec.rb
@@ -88,6 +88,18 @@ RSpec.describe DiscoursePrometheus::InternalMetric::Global do
     end
   end
 
+  describe "#sidekiq_queue_latency_seconds" do
+    it "collects the right metrics" do
+      fake_queue = Sidekiq::Queue.new("default")
+
+      Sidekiq::Queue.expects(:all).returns([fake_queue])
+
+      metric.collect
+
+      expect(metric.sidekiq_queue_latency_seconds).to eq({ queue: "default" } => 0)
+    end
+  end
+
   describe "when a replica has been configured" do
     before do
       config = ActiveRecord::Base.connection_db_config.configuration_hash.dup


### PR DESCRIPTION
This is a useful metric for us to track and can be used to supplement
the `sidekiq_jobs_enqueued` metric to determine if a queue is
overloaded.
