### PR TITLE
FIX: Broken `scheduled_job_ran` metric

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -65,7 +65,7 @@ after_initialize do
     metric.job_name = stat.name
     metric.duration = stat.duration_ms * 0.001
     metric.count = 1
-    metric.success = stats.success
+    metric.success = stat.success
     $prometheus_client.send_json metric.to_h unless Rails.env.test?
   end
 


### PR DESCRIPTION
Follow-up to e1eeb65d1737c2df5963ad63fda1620daf1d1d89

This is difficult to test so I'm going to accept the risk here.