### PR TITLE
FIX: Switch duration web metrics to histogram type

### DIFF
--- a/lib/collector.rb
+++ b/lib/collector.rb
@@ -7,7 +7,7 @@ module ::DiscoursePrometheus
     # convenience shortcuts
     Gauge = ::PrometheusExporter::Metric::Gauge
     Counter = ::PrometheusExporter::Metric::Counter
-    Summary = ::PrometheusExporter::Metric::Summary
+    Histogram = ::PrometheusExporter::Metric::Histogram
 
     def initialize
       @page_views = nil
@@ -237,6 +237,8 @@ module ::DiscoursePrometheus
       @process_metrics << metric
     end
 
+    HTTP_DURATION_HISTOGRAM_BUCKETS = [0.01, 0.05, 0.1, 0.2, 0.4, 0.8, 1, 15, 30]
+
     def ensure_web_metrics
       unless @page_views
         @page_views = Counter.new("page_views", "Page views reported by admin dashboard")
@@ -248,36 +250,52 @@ module ::DiscoursePrometheus
           )
 
         @http_duration_seconds =
-          Summary.new("http_duration_seconds", "Time spent in HTTP reqs in seconds")
+          Histogram.new(
+            "http_duration_seconds",
+            "Time spent in HTTP reqs in seconds",
+            buckets: HTTP_DURATION_HISTOGRAM_BUCKETS,
+          )
 
         @http_application_duration_seconds =
-          Summary.new(
+          Histogram.new(
             "http_application_duration_seconds",
             "Time spent in application code within HTTP reqs in seconds",
+            buckets: HTTP_DURATION_HISTOGRAM_BUCKETS,
           )
 
         @http_redis_duration_seconds =
-          Summary.new(
+          Histogram.new(
             "http_redis_duration_seconds",
             "Time spent in Redis within HTTP reqs redis seconds",
+            buckets: HTTP_DURATION_HISTOGRAM_BUCKETS,
           )
 
         @http_sql_duration_seconds =
-          Summary.new("http_sql_duration_seconds", "Time spent in SQL within HTTP reqs in seconds")
+          Histogram.new(
+            "http_sql_duration_seconds",
+            "Time spent in SQL within HTTP reqs in seconds",
+            buckets: HTTP_DURATION_HISTOGRAM_BUCKETS,
+          )
 
         @http_net_duration_seconds =
-          Summary.new("http_net_duration_seconds", "Time spent in external network requests")
+          Histogram.new(
+            "http_net_duration_seconds",
+            "Time spent in external network requests",
+            buckets: HTTP_DURATION_HISTOGRAM_BUCKETS,
+          )
 
         @http_queue_duration_seconds =
-          Summary.new(
+          Histogram.new(
             "http_queue_duration_seconds",
             "Time spent queueing requests between NGINX and Ruby",
+            buckets: HTTP_DURATION_HISTOGRAM_BUCKETS,
           )
 
         @http_gc_duration_seconds =
-          Summary.new(
+          Histogram.new(
             "http_gc_duration_seconds",
             "Time spent in garbage collection within HTTP reqs in seconds",
+            buckets: HTTP_DURATION_HISTOGRAM_BUCKETS,
           )
 
         @http_gc_major_count =
@@ -305,8 +323,6 @@ module ::DiscoursePrometheus
 
     def process_web(metric)
       ensure_web_metrics
-      # STDERR.puts metric.to_h.inspect
-      # STDERR.puts metric.controller.to_s + " " + metric.action.to_s
 
       labels = {
         cache: !!metric.cache,

--- a/spec/lib/collector_spec.rb
+++ b/spec/lib/collector_spec.rb
@@ -345,9 +345,11 @@ RSpec.describe DiscoursePrometheus::Collector do
     exported = collector.prometheus_metrics
 
     assert_metric = ->(metric_name, sum) do
-      metrics = exported.find { |metric| metric.name == metric_name }
+      metric = exported.find { |m| m.name == metric_name }
 
-      expect(metrics.to_h).to eq(
+      expect(metric.type).to eq("histogram")
+
+      expect(metric.to_h).to eq(
         {
           controller: "list",
           action: "latest",


### PR DESCRIPTION
This is a bug fix that switches the `http_.*_duration_seconds`
web metrics from a summary to a histogram type because summaries cannot be
aggregated and that makes it practically useless in a multi-instance
setup. As such, switching to a histogram allows us to better support
both single instance and multi-instance setups.

This is unfortunately a breaking change but we have decided to accept
the risk given that there is likely to be low usage of this plugin.

### Reviewer notes

The difference between histogram and summary is explained in  https://prometheus.io/docs/practices/histograms/
