### PR TITLE
DEV: Remove unused `cache` label for duration metrics

### DIFF
--- a/lib/collector.rb
+++ b/lib/collector.rb
@@ -370,7 +370,6 @@ module ::DiscoursePrometheus
       ensure_web_metrics
 
       labels = {
-        cache: !!metric.cache,
         success: (200..299).include?(metric.status_code),
         content_type: web_metric_content_type(metric),
         logged_in: metric.logged_in,

--- a/spec/lib/collector_spec.rb
+++ b/spec/lib/collector_spec.rb
@@ -337,7 +337,6 @@ RSpec.describe DiscoursePrometheus::Collector do
       queue_duration: 7,
       controller: "list",
       action: "latest",
-      cache: true,
       logged_in: false,
       html: true,
     )
@@ -356,7 +355,6 @@ RSpec.describe DiscoursePrometheus::Collector do
           controller: "list",
           action: "latest",
           success: true,
-          cache: false,
           logged_in: true,
           content_type: "json",
         } => {
@@ -367,7 +365,6 @@ RSpec.describe DiscoursePrometheus::Collector do
           controller: "list",
           action: "latest",
           success: false,
-          cache: true,
           logged_in: false,
           content_type: "html",
         } => {
@@ -401,7 +398,6 @@ RSpec.describe DiscoursePrometheus::Collector do
         controller: "list",
         action: "latest",
         success: true,
-        cache: false,
         logged_in: true,
         content_type: "json",
       } =>
@@ -410,7 +406,6 @@ RSpec.describe DiscoursePrometheus::Collector do
         controller: "list",
         action: "latest",
         success: false,
-        cache: true,
         logged_in: false,
         content_type: "html",
       } =>
@@ -422,7 +417,6 @@ RSpec.describe DiscoursePrometheus::Collector do
         controller: "list",
         action: "latest",
         success: true,
-        cache: false,
         logged_in: true,
         content_type: "json",
       } =>
@@ -431,7 +425,6 @@ RSpec.describe DiscoursePrometheus::Collector do
         controller: "list",
         action: "latest",
         success: false,
-        cache: true,
         logged_in: false,
         content_type: "html",
       } =>


### PR DESCRIPTION
This increases the cardinality of the metrics while not really providing
meaningful information so we don't think adding this label is worth the
trade-offs.
