### PR TITLE
PERF: Drop custom labels from http queue duration metrics

### DIFF
--- a/lib/collector.rb
+++ b/lib/collector.rb
@@ -408,8 +408,8 @@ module ::DiscoursePrometheus
       @http_net_duration_seconds.observe(metric.net_duration, labels)
       @http_requests_net_duration_seconds.observe(metric.net_duration, labels)
 
-      @http_queue_duration_seconds.observe(metric.queue_duration, labels)
-      @http_requests_queue_duration_seconds.observe(metric.queue_duration, labels)
+      @http_queue_duration_seconds.observe(metric.queue_duration)
+      @http_requests_queue_duration_seconds.observe(metric.queue_duration)
 
       @http_sql_calls_per_request.observe(metric.sql_calls, labels)
 


### PR DESCRIPTION
This commit drops the custom labels from the `http_queue_duration_seconds` and
`http_requests_queue_duration_seconds` metric as those labels do not add
any value to the metric. This change helps to reduce the cardinality
of the metrics which in turn helps to reduce metric storage cost.

### Reviewer notes

#### Before

`discourse_http_queue_duration_seconds{action="other", cache="false", content_type="other", controller="other", instance="<something>", job="<some job>", logged_in="false", node="<some node>", quantile="0.99", success="true"}`

#### After

`discourse_http_queue_duration_seconds{instance="<something>", job="<some job>", node="<some node>", quantile="0.99"}`