### PR TITLE
FEATURE: Update hist buckets for `http_requests_queue_duration_seconds`

### DIFF
--- a/lib/collector.rb
+++ b/lib/collector.rb
@@ -297,7 +297,7 @@ module ::DiscoursePrometheus
           Histogram.new(
             "http_requests_queue_duration_seconds",
             "Time spent queueing requests between NGINX and Ruby in seconds",
-            buckets: HTTP_DURATION_HISTOGRAM_BUCKETS,
+            buckets: [0.002, 0.004, 0.008, 0.01, 0.02, 0.05, 0.1],
           )
 
         @http_requests_gc_duration_seconds =

--- a/spec/lib/collector_spec.rb
+++ b/spec/lib/collector_spec.rb
@@ -318,6 +318,7 @@ RSpec.describe DiscoursePrometheus::Collector do
       gc_duration: 4,
       gc_major_count: 5,
       gc_minor_count: 6,
+      queue_duration: 7,
       json: true,
       controller: "list",
       action: "latest",
@@ -333,6 +334,7 @@ RSpec.describe DiscoursePrometheus::Collector do
       gc_duration: 4,
       gc_major_count: 5,
       gc_minor_count: 6,
+      queue_duration: 7,
       controller: "list",
       action: "latest",
       cache: true,
@@ -389,6 +391,10 @@ RSpec.describe DiscoursePrometheus::Collector do
       ["http_requests_net_duration_seconds", 3.0, "histogram"],
       ["http_requests_gc_duration_seconds", 4.0, "histogram"],
     ].each { |args| assert_metric.call(*args) }
+
+    expect(
+      exported.find { |metric| metric.name == "http_requests_queue_duration_seconds" }.to_h,
+    ).to eq({} => { "count" => 2, "sum" => 14.0 })
 
     expect(exported.find { |metric| metric.name == "http_gc_major_count" }.to_h).to eq(
       {


### PR DESCRIPTION
Request queue duration happens within a smaller range of value as
compared to other request durations. Therefore, we need to tweak the
values of the buckets that better reflect the expected range of values.

### Reviewer notes

See https://prometheus.io/docs/practices/histograms/#quantiles which states the following for histograms.

> Pick buckets suitable for the expected range of observed values.

