### PR TITLE
FIX: Parse Sidekiq::Work payload to extract job_name

### DIFF
--- a/lib/internal_metric/global.rb
+++ b/lib/internal_metric/global.rb
@@ -360,7 +360,7 @@ module DiscoursePrometheus::InternalMetric
       Sidekiq::Workers.new.each do |queue, tid, work|
         next unless queue.start_with?(hostname)
         next if Time.at(work.run_at) >= (Time.now - 60 * STUCK_SIDEKIQ_JOB_MINUTES)
-        labels = { job_name: JSON.parse(work.payload)["class"] }
+        labels = { job_name: work.job["class"] }
         stats[labels] ||= 0
         stats[labels] += 1
       end

--- a/lib/internal_metric/global.rb
+++ b/lib/internal_metric/global.rb
@@ -359,8 +359,8 @@ module DiscoursePrometheus::InternalMetric
       stats = {}
       Sidekiq::Workers.new.each do |queue, tid, work|
         next unless queue.start_with?(hostname)
-        next if Time.at(work["run_at"]) >= (Time.now - 60 * STUCK_SIDEKIQ_JOB_MINUTES)
-        labels = { job_name: work.dig("payload", "class") }
+        next if Time.at(work.run_at) >= (Time.now - 60 * STUCK_SIDEKIQ_JOB_MINUTES)
+        labels = { job_name: JSON.parse(work.payload)["class"] }
         stats[labels] ||= 0
         stats[labels] += 1
       end

--- a/spec/lib/internal_metric/global_spec.rb
+++ b/spec/lib/internal_metric/global_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe DiscoursePrometheus::InternalMetric::Global do
   end
 
   describe "#find_stuck_sidekiq_jobs" do
-    it "collects the right metrics" do
+    before do
       allow(Sidekiq::Workers).to receive(:new).and_return(
         [
           [
@@ -127,7 +127,9 @@ RSpec.describe DiscoursePrometheus::InternalMetric::Global do
           ],
         ],
       )
+    end
 
+    it "collects the right metrics" do
       metric.collect
 
       expect(metric.sidekiq_jobs_stuck).to eq({ { job_name: "Jobs::Foo" } => 1 })


### PR DESCRIPTION
Discourse's Sidekiq was recently updated from 6.5.12 to 7.3.9. Since 7.2.1, `Sidekiq::Work` has replaced the third parameter of `Sidekiq::WorkSet#each`, which used to be a raw hash.