### PR TITLE
FEATURE: Export image-processing duration

### DIFF
--- a/bin/collector
+++ b/bin/collector
@@ -27,6 +27,7 @@ require_relative "../lib/internal_metric/job"
 require_relative "../lib/internal_metric/process"
 require_relative "../lib/internal_metric/web"
 require_relative "../lib/internal_metric/custom"
+require_relative "../lib/internal_metric/image_processing"
 require_relative "../lib/collector"
 
 $port = ARGV[0].to_i

--- a/lib/collector.rb
+++ b/lib/collector.rb
@@ -10,6 +10,15 @@ module ::DiscoursePrometheus
     Summary = ::PrometheusExporter::Metric::Summary
     Histogram = ::PrometheusExporter::Metric::Histogram
 
+    IMAGE_PROCESSING_DURATION_BUCKETS = [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30]
+    IMAGE_PROCESSING_CPU_BUCKETS = [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300]
+    IMAGE_PROCESSING_MAX_RSS_BUCKETS =
+      [1, 4, 16, 64, 128, 256, 512, 1024, 2048, 4096].map { |megabytes| megabytes * 1024 * 1024 }
+
+    private_constant :IMAGE_PROCESSING_DURATION_BUCKETS,
+                     :IMAGE_PROCESSING_CPU_BUCKETS,
+                     :IMAGE_PROCESSING_MAX_RSS_BUCKETS
+
     class UnknownMetricTypeError < StandardError
     end
 
@@ -47,6 +56,10 @@ module ::DiscoursePrometheus
       @global_metrics = []
 
       @custom_metrics = nil
+
+      @image_processing_duration_seconds = nil
+      @image_processing_cpu_seconds = nil
+      @image_processing_max_rss_bytes = nil
     end
 
     def process(str)
@@ -66,6 +79,8 @@ module ::DiscoursePrometheus
         process_global(metric)
       elsif InternalMetric::Custom === metric
         process_custom(metric)
+      elsif InternalMetric::ImageProcessing === metric
+        process_image_processing(metric)
       end
     rescue => e
       metric_name =
@@ -508,12 +523,62 @@ module ::DiscoursePrometheus
     end
 
     def prometheus_metrics
-      metrics = web_metrics + process_metrics + job_metrics + @global_metrics
+      metrics =
+        web_metrics + process_metrics + job_metrics + image_processing_metrics + @global_metrics
       metrics += @custom_metrics.values if @custom_metrics
       metrics
     end
 
     private
+
+    def process_image_processing(metric)
+      ensure_image_processing_metrics
+
+      labels = {
+        "operation" => metric.operation.to_s,
+        "success" => metric.success.to_s,
+        "error_reason" => metric.error_reason.to_s,
+      }
+
+      @image_processing_duration_seconds.observe(metric.duration_seconds, labels)
+      @image_processing_cpu_seconds.observe(metric.cpu_seconds, labels)
+      @image_processing_max_rss_bytes.observe(metric.max_rss_bytes, labels)
+    end
+
+    def ensure_image_processing_metrics
+      return if @image_processing_duration_seconds
+
+      @image_processing_duration_seconds =
+        Histogram.new(
+          "image_processing_duration_seconds",
+          "Wall-clock duration of image-processing operations",
+          buckets: IMAGE_PROCESSING_DURATION_BUCKETS,
+        )
+      @image_processing_cpu_seconds =
+        Histogram.new(
+          "image_processing_cpu_seconds",
+          "CPU time consumed by image-processing operations",
+          buckets: IMAGE_PROCESSING_CPU_BUCKETS,
+        )
+      @image_processing_max_rss_bytes =
+        Histogram.new(
+          "image_processing_max_rss_bytes",
+          "Peak resident memory used by image-processing operations",
+          buckets: IMAGE_PROCESSING_MAX_RSS_BUCKETS,
+        )
+    end
+
+    def image_processing_metrics
+      if @image_processing_duration_seconds
+        [
+          @image_processing_duration_seconds,
+          @image_processing_cpu_seconds,
+          @image_processing_max_rss_bytes,
+        ]
+      else
+        []
+      end
+    end
 
     def job_metrics
       if @scheduled_job_duration_seconds

--- a/lib/collector.rb
+++ b/lib/collector.rb
@@ -11,13 +11,16 @@ module ::DiscoursePrometheus
     Histogram = ::PrometheusExporter::Metric::Histogram
 
     IMAGE_PROCESSING_DURATION_BUCKETS = [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30]
-    IMAGE_PROCESSING_CPU_BUCKETS = [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300]
-    IMAGE_PROCESSING_MAX_RSS_BUCKETS =
-      [1, 4, 16, 64, 128, 256, 512, 1024, 2048, 4096].map { |megabytes| megabytes * 1024 * 1024 }
+    IMAGE_PROCESSING_ERROR_REASONS = %w[
+      wall_timeout
+      cpu_limit
+      file_size_limit
+      signal
+      nonzero_exit
+      exception
+    ].freeze
 
-    private_constant :IMAGE_PROCESSING_DURATION_BUCKETS,
-                     :IMAGE_PROCESSING_CPU_BUCKETS,
-                     :IMAGE_PROCESSING_MAX_RSS_BUCKETS
+    private_constant :IMAGE_PROCESSING_DURATION_BUCKETS, :IMAGE_PROCESSING_ERROR_REASONS
 
     class UnknownMetricTypeError < StandardError
     end
@@ -57,9 +60,7 @@ module ::DiscoursePrometheus
 
       @custom_metrics = nil
 
-      @image_processing_duration_seconds = nil
-      @image_processing_cpu_seconds = nil
-      @image_processing_max_rss_bytes = nil
+      @image_processing_command_duration_seconds = nil
     end
 
     def process(str)
@@ -532,52 +533,42 @@ module ::DiscoursePrometheus
     private
 
     def process_image_processing(metric)
+      labels = image_processing_labels(metric)
       ensure_image_processing_metrics
 
-      labels = {
-        "operation" => metric.operation.to_s,
-        "success" => metric.success.to_s,
-        "error_reason" => metric.error_reason.to_s,
-      }
+      @image_processing_command_duration_seconds.observe(metric.duration_seconds, labels)
+    end
 
-      @image_processing_duration_seconds.observe(metric.duration_seconds, labels)
-      @image_processing_cpu_seconds.observe(metric.cpu_seconds, labels)
-      @image_processing_max_rss_bytes.observe(metric.max_rss_bytes, labels)
+    def image_processing_labels(metric)
+      status = metric.success ? "success" : "error"
+      error_reason = metric.error_reason.to_s
+
+      if metric.success != true && metric.success != false
+        raise ArgumentError, "image-processing success must be true or false"
+      end
+      if metric.success && !error_reason.empty?
+        raise ArgumentError, "successful image-processing metrics cannot have an error reason"
+      end
+      if !metric.success && !IMAGE_PROCESSING_ERROR_REASONS.include?(error_reason)
+        raise ArgumentError, "unknown image-processing error reason"
+      end
+
+      { "operation" => metric.operation.to_s, "status" => status, "error_reason" => error_reason }
     end
 
     def ensure_image_processing_metrics
-      return if @image_processing_duration_seconds
+      return if @image_processing_command_duration_seconds
 
-      @image_processing_duration_seconds =
+      @image_processing_command_duration_seconds =
         Histogram.new(
-          "image_processing_duration_seconds",
-          "Wall-clock duration of image-processing operations",
+          "image_processing_command_duration_seconds",
+          "Wall-clock duration of image-processing commands",
           buckets: IMAGE_PROCESSING_DURATION_BUCKETS,
-        )
-      @image_processing_cpu_seconds =
-        Histogram.new(
-          "image_processing_cpu_seconds",
-          "CPU time consumed by image-processing operations",
-          buckets: IMAGE_PROCESSING_CPU_BUCKETS,
-        )
-      @image_processing_max_rss_bytes =
-        Histogram.new(
-          "image_processing_max_rss_bytes",
-          "Peak resident memory used by image-processing operations",
-          buckets: IMAGE_PROCESSING_MAX_RSS_BUCKETS,
         )
     end
 
     def image_processing_metrics
-      if @image_processing_duration_seconds
-        [
-          @image_processing_duration_seconds,
-          @image_processing_cpu_seconds,
-          @image_processing_max_rss_bytes,
-        ]
-      else
-        []
-      end
+      @image_processing_command_duration_seconds ? [@image_processing_command_duration_seconds] : []
     end
 
     def job_metrics

--- a/lib/collector.rb
+++ b/lib/collector.rb
@@ -11,17 +11,8 @@ module ::DiscoursePrometheus
     Histogram = ::PrometheusExporter::Metric::Histogram
 
     IMAGE_PROCESSING_DURATION_BUCKETS = [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30]
-    IMAGE_PROCESSING_RESULTS = %w[
-      success
-      wall_timeout
-      cpu_limit
-      file_size_limit
-      signal
-      nonzero_exit
-      exception
-    ].freeze
 
-    private_constant :IMAGE_PROCESSING_DURATION_BUCKETS, :IMAGE_PROCESSING_RESULTS
+    private_constant :IMAGE_PROCESSING_DURATION_BUCKETS
 
     class UnknownMetricTypeError < StandardError
     end
@@ -539,7 +530,7 @@ module ::DiscoursePrometheus
 
       @image_processing_command_duration_seconds.observe(
         metric.duration_seconds,
-        { "operation" => metric.operation, "result" => metric.result },
+        { "operation" => metric.operation, "success" => metric.success.to_s },
       )
     end
 
@@ -555,8 +546,8 @@ module ::DiscoursePrometheus
               "image-processing duration_seconds must be a finite non-negative number"
       end
 
-      if !metric.result.is_a?(String) || !IMAGE_PROCESSING_RESULTS.include?(metric.result)
-        raise ArgumentError, "unknown image-processing result"
+      if metric.success != true && metric.success != false
+        raise ArgumentError, "image-processing success must be true or false"
       end
     end
 

--- a/lib/collector.rb
+++ b/lib/collector.rb
@@ -11,7 +11,8 @@ module ::DiscoursePrometheus
     Histogram = ::PrometheusExporter::Metric::Histogram
 
     IMAGE_PROCESSING_DURATION_BUCKETS = [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30]
-    IMAGE_PROCESSING_ERROR_REASONS = %w[
+    IMAGE_PROCESSING_RESULTS = %w[
+      success
       wall_timeout
       cpu_limit
       file_size_limit
@@ -20,7 +21,7 @@ module ::DiscoursePrometheus
       exception
     ].freeze
 
-    private_constant :IMAGE_PROCESSING_DURATION_BUCKETS, :IMAGE_PROCESSING_ERROR_REASONS
+    private_constant :IMAGE_PROCESSING_DURATION_BUCKETS, :IMAGE_PROCESSING_RESULTS
 
     class UnknownMetricTypeError < StandardError
     end
@@ -534,10 +535,12 @@ module ::DiscoursePrometheus
 
     def process_image_processing(metric)
       validate_image_processing_metric!(metric)
-      labels = image_processing_labels(metric)
       ensure_image_processing_metrics
 
-      @image_processing_command_duration_seconds.observe(metric.duration_seconds, labels)
+      @image_processing_command_duration_seconds.observe(
+        metric.duration_seconds,
+        { "operation" => metric.operation, "result" => metric.result },
+      )
     end
 
     def validate_image_processing_metric!(metric)
@@ -551,23 +554,10 @@ module ::DiscoursePrometheus
         raise ArgumentError,
               "image-processing duration_seconds must be a finite non-negative number"
       end
-    end
 
-    def image_processing_labels(metric)
-      status = metric.success ? "success" : "error"
-      error_reason = metric.error_reason.to_s
-
-      if metric.success != true && metric.success != false
-        raise ArgumentError, "image-processing success must be true or false"
+      if !metric.result.is_a?(String) || !IMAGE_PROCESSING_RESULTS.include?(metric.result)
+        raise ArgumentError, "unknown image-processing result"
       end
-      if metric.success && !error_reason.empty?
-        raise ArgumentError, "successful image-processing metrics cannot have an error reason"
-      end
-      if !metric.success && !IMAGE_PROCESSING_ERROR_REASONS.include?(error_reason)
-        raise ArgumentError, "unknown image-processing error reason"
-      end
-
-      { "operation" => metric.operation.to_s, "status" => status, "error_reason" => error_reason }
     end
 
     def ensure_image_processing_metrics

--- a/lib/collector.rb
+++ b/lib/collector.rb
@@ -11,7 +11,6 @@ module ::DiscoursePrometheus
     Histogram = ::PrometheusExporter::Metric::Histogram
 
     IMAGE_PROCESSING_DURATION_BUCKETS = [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30]
-
     private_constant :IMAGE_PROCESSING_DURATION_BUCKETS
 
     class UnknownMetricTypeError < StandardError

--- a/lib/collector.rb
+++ b/lib/collector.rb
@@ -52,7 +52,7 @@ module ::DiscoursePrometheus
 
       @custom_metrics = nil
 
-      @image_processing_command_duration_seconds = nil
+      @image_processing_duration_seconds = nil
     end
 
     def process(str)
@@ -528,7 +528,7 @@ module ::DiscoursePrometheus
       validate_image_processing_metric!(metric)
       ensure_image_processing_metrics
 
-      @image_processing_command_duration_seconds.observe(
+      @image_processing_duration_seconds.observe(
         metric.duration_seconds,
         { "operation" => metric.operation, "success" => metric.success.to_s },
       )
@@ -552,18 +552,18 @@ module ::DiscoursePrometheus
     end
 
     def ensure_image_processing_metrics
-      return if @image_processing_command_duration_seconds
+      return if @image_processing_duration_seconds
 
-      @image_processing_command_duration_seconds =
+      @image_processing_duration_seconds =
         Histogram.new(
-          "image_processing_command_duration_seconds",
+          "image_processing_duration_seconds",
           "Wall-clock duration of image-processing commands",
           buckets: IMAGE_PROCESSING_DURATION_BUCKETS,
         )
     end
 
     def image_processing_metrics
-      @image_processing_command_duration_seconds ? [@image_processing_command_duration_seconds] : []
+      @image_processing_duration_seconds ? [@image_processing_duration_seconds] : []
     end
 
     def job_metrics

--- a/lib/collector.rb
+++ b/lib/collector.rb
@@ -533,10 +533,24 @@ module ::DiscoursePrometheus
     private
 
     def process_image_processing(metric)
+      validate_image_processing_metric!(metric)
       labels = image_processing_labels(metric)
       ensure_image_processing_metrics
 
       @image_processing_command_duration_seconds.observe(metric.duration_seconds, labels)
+    end
+
+    def validate_image_processing_metric!(metric)
+      if !metric.operation.is_a?(String) || metric.operation.empty?
+        raise ArgumentError, "image-processing operation must be a non-empty string"
+      end
+
+      duration_seconds = metric.duration_seconds
+      if !duration_seconds.is_a?(Numeric) || !duration_seconds.real? || !duration_seconds.finite? ||
+           duration_seconds.negative?
+        raise ArgumentError,
+              "image-processing duration_seconds must be a finite non-negative number"
+      end
     end
 
     def image_processing_labels(metric)

--- a/lib/internal_metric/base.rb
+++ b/lib/internal_metric/base.rb
@@ -24,6 +24,8 @@ module DiscoursePrometheus::InternalMetric
           Process
         when "Custom"
           Custom
+        when "ImageProcessing"
+          ImageProcessing
         else
           raise "class deserialization not implemented"
         end
@@ -60,6 +62,8 @@ module DiscoursePrometheus::InternalMetric
           "Process"
         when Custom
           "Custom"
+        when ImageProcessing
+          "ImageProcessing"
         else
           raise "not implemented"
         end

--- a/lib/internal_metric/image_processing.rb
+++ b/lib/internal_metric/image_processing.rb
@@ -2,6 +2,6 @@
 
 module DiscoursePrometheus::InternalMetric
   class ImageProcessing < Base
-    attribute(:operation, :success, :error_reason, :duration_seconds, :cpu_seconds, :max_rss_bytes)
+    attribute(:operation, :success, :error_reason, :duration_seconds)
   end
 end

--- a/lib/internal_metric/image_processing.rb
+++ b/lib/internal_metric/image_processing.rb
@@ -2,6 +2,6 @@
 
 module DiscoursePrometheus::InternalMetric
   class ImageProcessing < Base
-    attribute(:operation, :result, :duration_seconds)
+    attribute(:operation, :duration_seconds, :success)
   end
 end

--- a/lib/internal_metric/image_processing.rb
+++ b/lib/internal_metric/image_processing.rb
@@ -2,6 +2,6 @@
 
 module DiscoursePrometheus::InternalMetric
   class ImageProcessing < Base
-    attribute(:operation, :success, :error_reason, :duration_seconds)
+    attribute(:operation, :result, :duration_seconds)
   end
 end

--- a/lib/internal_metric/image_processing.rb
+++ b/lib/internal_metric/image_processing.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module DiscoursePrometheus::InternalMetric
+  class ImageProcessing < Base
+    attribute(:operation, :success, :error_reason, :duration_seconds, :cpu_seconds, :max_rss_bytes)
+  end
+end

--- a/lib/reporter/image_processing.rb
+++ b/lib/reporter/image_processing.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module DiscoursePrometheus::Reporter
+  class ImageProcessing
+    def initialize(client)
+      @client = client
+    end
+
+    def report(payload)
+      metric = DiscoursePrometheus::InternalMetric::ImageProcessing.new
+      DiscoursePrometheus::InternalMetric::ImageProcessing.attributes.each do |attribute|
+        metric.public_send("#{attribute}=", payload.fetch(attribute))
+      end
+      @client.send_json(metric.to_h)
+      nil
+    end
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -20,10 +20,12 @@ require_relative("lib/internal_metric/job")
 require_relative("lib/internal_metric/process")
 require_relative("lib/internal_metric/web")
 require_relative("lib/internal_metric/custom")
+require_relative("lib/internal_metric/image_processing")
 
 require_relative("lib/reporter/process")
 require_relative("lib/reporter/global")
 require_relative("lib/reporter/web")
+require_relative("lib/reporter/image_processing")
 
 require_relative("lib/collector_demon")
 require_relative("lib/global_reporter_demon")
@@ -47,6 +49,11 @@ after_initialize do
 
   # creates no new threads, this simply adds the instruments
   DiscoursePrometheus::Reporter::Web.start($prometheus_client) unless Rails.env.test?
+  image_processing_reporter = DiscoursePrometheus::Reporter::ImageProcessing.new($prometheus_client)
+
+  on(:image_processing_finished) do |payload|
+    image_processing_reporter.report(payload) unless Rails.env.test?
+  end
 
   register_demon_process(DiscoursePrometheus::CollectorDemon)
   register_demon_process(DiscoursePrometheus::GlobalReporterDemon)

--- a/plugin.rb
+++ b/plugin.rb
@@ -51,9 +51,7 @@ after_initialize do
   DiscoursePrometheus::Reporter::Web.start($prometheus_client) unless Rails.env.test?
   image_processing_reporter = DiscoursePrometheus::Reporter::ImageProcessing.new($prometheus_client)
 
-  on(:image_processing_finished) do |payload|
-    image_processing_reporter.report(payload) unless Rails.env.test?
-  end
+  on(:image_processing_finished) { |payload| image_processing_reporter.report(payload) }
 
   register_demon_process(DiscoursePrometheus::CollectorDemon)
   register_demon_process(DiscoursePrometheus::GlobalReporterDemon)

--- a/spec/lib/image_processing_collector_spec.rb
+++ b/spec/lib/image_processing_collector_spec.rb
@@ -91,7 +91,6 @@ RSpec.describe DiscoursePrometheus::Collector do
     it "exports an image-processing event through the public Prometheus exposition" do
       original_prefix = PrometheusExporter::Metric::Base.default_prefix
       PrometheusExporter::Metric::Base.default_prefix = "discourse_"
-      allow(Rails.env).to receive(:test?).and_return(false)
       allow($prometheus_client).to receive(:send_json) do |metric|
         collector.process(Oj.dump(metric, mode: :object))
       end

--- a/spec/lib/image_processing_collector_spec.rb
+++ b/spec/lib/image_processing_collector_spec.rb
@@ -84,7 +84,9 @@ RSpec.describe DiscoursePrometheus::Collector do
         },
       )
     end
+  end
 
+  describe "#prometheus_metrics_text" do
     it "exports an image-processing event through the public Prometheus exposition" do
       original_prefix = PrometheusExporter::Metric::Base.default_prefix
       PrometheusExporter::Metric::Base.default_prefix = "discourse_"
@@ -93,7 +95,7 @@ RSpec.describe DiscoursePrometheus::Collector do
         collector.process(Oj.dump(metric, mode: :object))
       end
 
-      expect(collector.prometheus_metrics_text).not_to include("discourse_image_processing")
+      expect(collector.prometheus_metrics_text).to be_empty
 
       DiscourseEvent.trigger(
         :image_processing_finished,
@@ -119,6 +121,24 @@ RSpec.describe DiscoursePrometheus::Collector do
       )
     ensure
       PrometheusExporter::Metric::Base.default_prefix = original_prefix
+    end
+
+    it "rejects incomplete image-processing events without reporting observations" do
+      allow(Rails.env).to receive(:test?).and_return(false)
+      $prometheus_client.expects(:send_json).never
+      incomplete_payload = {
+        operation: "optimized_image_resize",
+        success: true,
+        error_reason: "none",
+        duration_seconds: 0.25,
+        cpu_seconds: 0.1,
+      }
+
+      expect {
+        DiscourseEvent.trigger(:image_processing_finished, incomplete_payload)
+      }.to raise_error(KeyError, /max_rss_bytes/)
+
+      expect(collector.prometheus_metrics_text).to be_empty
     end
   end
 end

--- a/spec/lib/image_processing_collector_spec.rb
+++ b/spec/lib/image_processing_collector_spec.rb
@@ -25,11 +25,11 @@ RSpec.describe DiscoursePrometheus::Collector do
       successful_labels = { "operation" => "optimized_image_resize", "success" => "true" }
       failed_labels = { "operation" => "topic_og_render", "success" => "false" }
 
-      expect(metrics.keys).to eq(["image_processing_command_duration_seconds"])
-      expect(metrics["image_processing_command_duration_seconds"].buckets).to eq(
+      expect(metrics.keys).to eq(["image_processing_duration_seconds"])
+      expect(metrics["image_processing_duration_seconds"].buckets).to eq(
         [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30],
       )
-      observations = metrics["image_processing_command_duration_seconds"].to_h
+      observations = metrics["image_processing_duration_seconds"].to_h
       expect(observations).to eq(
         successful_labels => {
           "count" => 1,
@@ -106,10 +106,10 @@ RSpec.describe DiscoursePrometheus::Collector do
       metrics_text = collector.prometheus_metrics_text
 
       expect(metrics_text).to include(
-        "# TYPE discourse_image_processing_command_duration_seconds histogram",
-        'discourse_image_processing_command_duration_seconds_bucket{operation="optimized_image_crop",success="false",le="0.25"} 1',
-        'discourse_image_processing_command_duration_seconds_count{operation="optimized_image_crop",success="false"} 1',
-        'discourse_image_processing_command_duration_seconds_sum{operation="optimized_image_crop",success="false"} 0.25',
+        "# TYPE discourse_image_processing_duration_seconds histogram",
+        'discourse_image_processing_duration_seconds_bucket{operation="optimized_image_crop",success="false",le="0.25"} 1',
+        'discourse_image_processing_duration_seconds_count{operation="optimized_image_crop",success="false"} 1',
+        'discourse_image_processing_duration_seconds_sum{operation="optimized_image_crop",success="false"} 0.25',
       )
     ensure
       PrometheusExporter::Metric::Base.default_prefix = original_prefix

--- a/spec/lib/image_processing_collector_spec.rb
+++ b/spec/lib/image_processing_collector_spec.rb
@@ -122,21 +122,5 @@ RSpec.describe DiscoursePrometheus::Collector do
     ensure
       PrometheusExporter::Metric::Base.default_prefix = original_prefix
     end
-
-    it "rejects incomplete image-processing events without reporting observations" do
-      allow(Rails.env).to receive(:test?).and_return(false)
-      $prometheus_client.expects(:send_json).never
-      incomplete_payload = {
-        operation: "optimized_image_resize",
-        success: true,
-        error_reason: "none",
-        duration_seconds: 0.25,
-        cpu_seconds: 0.1,
-      }
-
-      expect {
-        DiscourseEvent.trigger(:image_processing_finished, incomplete_payload)
-      }.to raise_error(KeyError, /max_rss_bytes/)
-    end
   end
 end

--- a/spec/lib/image_processing_collector_spec.rb
+++ b/spec/lib/image_processing_collector_spec.rb
@@ -7,22 +7,18 @@ RSpec.describe DiscoursePrometheus::Collector do
   subject(:collector) { described_class.new }
 
   describe "#process" do
-    it "observes successful and failed image-processing results in all histograms" do
+    it "observes successful and failed image-processing command durations" do
       successful_metric = DiscoursePrometheus::InternalMetric::ImageProcessing.new
       successful_metric.operation = "optimized_image_resize"
       successful_metric.success = true
-      successful_metric.error_reason = "none"
+      successful_metric.error_reason = nil
       successful_metric.duration_seconds = 0.25
-      successful_metric.cpu_seconds = 0.1
-      successful_metric.max_rss_bytes = 16.megabytes
 
       failed_metric = DiscoursePrometheus::InternalMetric::ImageProcessing.new
       failed_metric.operation = "topic_og_render"
       failed_metric.success = false
       failed_metric.error_reason = "wall_timeout"
       failed_metric.duration_seconds = 20
-      failed_metric.cpu_seconds = 10
-      failed_metric.max_rss_bytes = 128.megabytes
 
       collector.process(successful_metric.to_json)
       collector.process(failed_metric.to_json)
@@ -30,24 +26,20 @@ RSpec.describe DiscoursePrometheus::Collector do
       metrics = collector.prometheus_metrics.index_by(&:name)
       successful_labels = {
         "operation" => "optimized_image_resize",
-        "success" => "true",
-        "error_reason" => "none",
+        "status" => "success",
+        "error_reason" => "",
       }
       failed_labels = {
         "operation" => "topic_og_render",
-        "success" => "false",
+        "status" => "error",
         "error_reason" => "wall_timeout",
       }
 
-      expect(metrics.keys).to include(
-        "image_processing_duration_seconds",
-        "image_processing_cpu_seconds",
-        "image_processing_max_rss_bytes",
-      )
-      expect(metrics["image_processing_duration_seconds"].buckets).to eq(
+      expect(metrics.keys).to include("image_processing_command_duration_seconds")
+      expect(metrics["image_processing_command_duration_seconds"].buckets).to eq(
         [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30],
       )
-      expect(metrics["image_processing_duration_seconds"].to_h).to eq(
+      expect(metrics["image_processing_command_duration_seconds"].to_h).to eq(
         successful_labels => {
           "count" => 1,
           "sum" => 0.25,
@@ -57,32 +49,28 @@ RSpec.describe DiscoursePrometheus::Collector do
           "sum" => 20.0,
         },
       )
-      expect(metrics["image_processing_cpu_seconds"].buckets).to eq(
-        [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300],
-      )
-      expect(metrics["image_processing_cpu_seconds"].to_h).to eq(
-        successful_labels => {
-          "count" => 1,
-          "sum" => 0.1,
-        },
-        failed_labels => {
-          "count" => 1,
-          "sum" => 10.0,
-        },
-      )
-      expect(metrics["image_processing_max_rss_bytes"].buckets).to eq(
-        [1, 4, 16, 64, 128, 256, 512, 1024, 2048, 4096].map(&:megabytes),
-      )
-      expect(metrics["image_processing_max_rss_bytes"].to_h).to eq(
-        successful_labels => {
-          "count" => 1,
-          "sum" => 16.megabytes.to_f,
-        },
-        failed_labels => {
-          "count" => 1,
-          "sum" => 128.megabytes.to_f,
-        },
-      )
+    end
+
+    it "rejects invalid status and error-reason payloads without observing them" do
+      invalid_metrics = [
+        { success: nil, error_reason: nil },
+        { success: true, error_reason: "nonzero_exit" },
+        { success: false, error_reason: "an exception message" },
+      ]
+
+      invalid_metrics.each do |attributes|
+        metric = DiscoursePrometheus::InternalMetric::ImageProcessing.new
+        metric.operation = "optimized_image_resize"
+        metric.duration_seconds = 0.25
+        metric.success = attributes[:success]
+        metric.error_reason = attributes[:error_reason]
+
+        expect { collector.process(metric.to_json) }.to raise_error(ArgumentError).and output(
+                /Prometheus collector failed to process metric unknown/,
+              ).to_stderr
+      end
+
+      expect(collector.prometheus_metrics).to be_empty
     end
   end
 
@@ -104,20 +92,16 @@ RSpec.describe DiscoursePrometheus::Collector do
           success: false,
           error_reason: "nonzero_exit",
           duration_seconds: 0.25,
-          cpu_seconds: 0.1,
-          max_rss_bytes: 16.megabytes,
         },
       )
 
       metrics_text = collector.prometheus_metrics_text
 
       expect(metrics_text).to include(
-        "# TYPE discourse_image_processing_duration_seconds histogram",
-        "# TYPE discourse_image_processing_cpu_seconds histogram",
-        "# TYPE discourse_image_processing_max_rss_bytes histogram",
-        'discourse_image_processing_duration_seconds_bucket{operation="optimized_image_crop",success="false",error_reason="nonzero_exit",le="0.25"} 1',
-        'discourse_image_processing_duration_seconds_count{operation="optimized_image_crop",success="false",error_reason="nonzero_exit"} 1',
-        'discourse_image_processing_duration_seconds_sum{operation="optimized_image_crop",success="false",error_reason="nonzero_exit"} 0.25',
+        "# TYPE discourse_image_processing_command_duration_seconds histogram",
+        'discourse_image_processing_command_duration_seconds_bucket{operation="optimized_image_crop",status="error",error_reason="nonzero_exit",le="0.25"} 1',
+        'discourse_image_processing_command_duration_seconds_count{operation="optimized_image_crop",status="error",error_reason="nonzero_exit"} 1',
+        'discourse_image_processing_command_duration_seconds_sum{operation="optimized_image_crop",status="error",error_reason="nonzero_exit"} 0.25',
       )
     ensure
       PrometheusExporter::Metric::Base.default_prefix = original_prefix

--- a/spec/lib/image_processing_collector_spec.rb
+++ b/spec/lib/image_processing_collector_spec.rb
@@ -10,30 +10,20 @@ RSpec.describe DiscoursePrometheus::Collector do
     it "observes successful and failed image-processing command durations" do
       successful_metric = DiscoursePrometheus::InternalMetric::ImageProcessing.new
       successful_metric.operation = "optimized_image_resize"
-      successful_metric.success = true
-      successful_metric.error_reason = nil
+      successful_metric.result = "success"
       successful_metric.duration_seconds = 0.25
 
       failed_metric = DiscoursePrometheus::InternalMetric::ImageProcessing.new
       failed_metric.operation = "topic_og_render"
-      failed_metric.success = false
-      failed_metric.error_reason = "wall_timeout"
+      failed_metric.result = "wall_timeout"
       failed_metric.duration_seconds = 20
 
       collector.process(successful_metric.to_json)
       collector.process(failed_metric.to_json)
 
       metrics = collector.prometheus_metrics.index_by(&:name)
-      successful_labels = {
-        "operation" => "optimized_image_resize",
-        "status" => "success",
-        "error_reason" => "",
-      }
-      failed_labels = {
-        "operation" => "topic_og_render",
-        "status" => "error",
-        "error_reason" => "wall_timeout",
-      }
+      successful_labels = { "operation" => "optimized_image_resize", "result" => "success" }
+      failed_labels = { "operation" => "topic_og_render", "result" => "wall_timeout" }
 
       expect(metrics.keys).to eq(["image_processing_command_duration_seconds"])
       expect(metrics["image_processing_command_duration_seconds"].buckets).to eq(
@@ -51,19 +41,14 @@ RSpec.describe DiscoursePrometheus::Collector do
       )
     end
 
-    it "rejects invalid status and error-reason payloads without observing them" do
-      invalid_metrics = [
-        { success: nil, error_reason: nil },
-        { success: true, error_reason: "nonzero_exit" },
-        { success: false, error_reason: "an exception message" },
-      ]
+    it "rejects invalid results without observing them" do
+      invalid_results = [nil, "", :success, "an exception message"]
 
-      invalid_metrics.each do |attributes|
+      invalid_results.each do |result|
         metric = DiscoursePrometheus::InternalMetric::ImageProcessing.new
         metric.operation = "optimized_image_resize"
         metric.duration_seconds = 0.25
-        metric.success = attributes[:success]
-        metric.error_reason = attributes[:error_reason]
+        metric.result = result
 
         expect { collector.process(metric.to_json) }.to raise_error(ArgumentError).and output(
                 /Prometheus collector failed to process metric unknown/,
@@ -71,6 +56,27 @@ RSpec.describe DiscoursePrometheus::Collector do
       end
 
       expect(collector.prometheus_metrics).to be_empty
+    end
+
+    it "accepts the complete bounded result vocabulary" do
+      results = %w[success wall_timeout cpu_limit file_size_limit signal nonzero_exit exception]
+
+      results.each do |result|
+        metric = DiscoursePrometheus::InternalMetric::ImageProcessing.new
+        metric.operation = "optimized_image_resize"
+        metric.duration_seconds = 0.25
+        metric.result = result
+
+        collector.process(metric.to_json)
+      end
+
+      duration_metric = collector.prometheus_metrics.sole
+      labels = duration_metric.to_h.keys
+
+      expect(labels.map { |metric_labels| metric_labels.fetch("result") }).to contain_exactly(
+        *results,
+      )
+      expect(labels.map(&:keys).uniq).to eq([%w[operation result]])
     end
 
     it "rejects invalid operations and durations without observing them" do
@@ -89,8 +95,7 @@ RSpec.describe DiscoursePrometheus::Collector do
         metric = DiscoursePrometheus::InternalMetric::ImageProcessing.new
         metric.operation = attributes[:operation]
         metric.duration_seconds = attributes[:duration_seconds]
-        metric.success = true
-        metric.error_reason = nil
+        metric.result = "success"
 
         expect { collector.process(metric.to_json) }.to raise_error(ArgumentError).and output(
                 /Prometheus collector failed to process metric unknown/,
@@ -114,21 +119,16 @@ RSpec.describe DiscoursePrometheus::Collector do
 
       DiscourseEvent.trigger(
         :image_processing_finished,
-        {
-          operation: "optimized_image_crop",
-          success: false,
-          error_reason: "nonzero_exit",
-          duration_seconds: 0.25,
-        },
+        { operation: "optimized_image_crop", result: "nonzero_exit", duration_seconds: 0.25 },
       )
 
       metrics_text = collector.prometheus_metrics_text
 
       expect(metrics_text).to include(
         "# TYPE discourse_image_processing_command_duration_seconds histogram",
-        'discourse_image_processing_command_duration_seconds_bucket{operation="optimized_image_crop",status="error",error_reason="nonzero_exit",le="0.25"} 1',
-        'discourse_image_processing_command_duration_seconds_count{operation="optimized_image_crop",status="error",error_reason="nonzero_exit"} 1',
-        'discourse_image_processing_command_duration_seconds_sum{operation="optimized_image_crop",status="error",error_reason="nonzero_exit"} 0.25',
+        'discourse_image_processing_command_duration_seconds_bucket{operation="optimized_image_crop",result="nonzero_exit",le="0.25"} 1',
+        'discourse_image_processing_command_duration_seconds_count{operation="optimized_image_crop",result="nonzero_exit"} 1',
+        'discourse_image_processing_command_duration_seconds_sum{operation="optimized_image_crop",result="nonzero_exit"} 0.25',
       )
     ensure
       PrometheusExporter::Metric::Base.default_prefix = original_prefix

--- a/spec/lib/image_processing_collector_spec.rb
+++ b/spec/lib/image_processing_collector_spec.rb
@@ -10,26 +10,27 @@ RSpec.describe DiscoursePrometheus::Collector do
     it "observes successful and failed image-processing command durations" do
       successful_metric = DiscoursePrometheus::InternalMetric::ImageProcessing.new
       successful_metric.operation = "optimized_image_resize"
-      successful_metric.result = "success"
       successful_metric.duration_seconds = 0.25
+      successful_metric.success = true
 
       failed_metric = DiscoursePrometheus::InternalMetric::ImageProcessing.new
       failed_metric.operation = "topic_og_render"
-      failed_metric.result = "wall_timeout"
       failed_metric.duration_seconds = 20
+      failed_metric.success = false
 
       collector.process(successful_metric.to_json)
       collector.process(failed_metric.to_json)
 
       metrics = collector.prometheus_metrics.index_by(&:name)
-      successful_labels = { "operation" => "optimized_image_resize", "result" => "success" }
-      failed_labels = { "operation" => "topic_og_render", "result" => "wall_timeout" }
+      successful_labels = { "operation" => "optimized_image_resize", "success" => "true" }
+      failed_labels = { "operation" => "topic_og_render", "success" => "false" }
 
       expect(metrics.keys).to eq(["image_processing_command_duration_seconds"])
       expect(metrics["image_processing_command_duration_seconds"].buckets).to eq(
         [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30],
       )
-      expect(metrics["image_processing_command_duration_seconds"].to_h).to eq(
+      observations = metrics["image_processing_command_duration_seconds"].to_h
+      expect(observations).to eq(
         successful_labels => {
           "count" => 1,
           "sum" => 0.25,
@@ -39,16 +40,17 @@ RSpec.describe DiscoursePrometheus::Collector do
           "sum" => 20.0,
         },
       )
+      expect(observations.keys.map(&:keys).uniq).to eq([%w[operation success]])
     end
 
-    it "rejects invalid results without observing them" do
-      invalid_results = [nil, "", :success, "an exception message"]
+    it "rejects non-Boolean success values without observing them" do
+      invalid_success_values = [nil, "", "true", 1, :success]
 
-      invalid_results.each do |result|
+      invalid_success_values.each do |success|
         metric = DiscoursePrometheus::InternalMetric::ImageProcessing.new
         metric.operation = "optimized_image_resize"
         metric.duration_seconds = 0.25
-        metric.result = result
+        metric.success = success
 
         expect { collector.process(metric.to_json) }.to raise_error(ArgumentError).and output(
                 /Prometheus collector failed to process metric unknown/,
@@ -56,27 +58,6 @@ RSpec.describe DiscoursePrometheus::Collector do
       end
 
       expect(collector.prometheus_metrics).to be_empty
-    end
-
-    it "accepts the complete bounded result vocabulary" do
-      results = %w[success wall_timeout cpu_limit file_size_limit signal nonzero_exit exception]
-
-      results.each do |result|
-        metric = DiscoursePrometheus::InternalMetric::ImageProcessing.new
-        metric.operation = "optimized_image_resize"
-        metric.duration_seconds = 0.25
-        metric.result = result
-
-        collector.process(metric.to_json)
-      end
-
-      duration_metric = collector.prometheus_metrics.sole
-      labels = duration_metric.to_h.keys
-
-      expect(labels.map { |metric_labels| metric_labels.fetch("result") }).to contain_exactly(
-        *results,
-      )
-      expect(labels.map(&:keys).uniq).to eq([%w[operation result]])
     end
 
     it "rejects invalid operations and durations without observing them" do
@@ -95,7 +76,7 @@ RSpec.describe DiscoursePrometheus::Collector do
         metric = DiscoursePrometheus::InternalMetric::ImageProcessing.new
         metric.operation = attributes[:operation]
         metric.duration_seconds = attributes[:duration_seconds]
-        metric.result = "success"
+        metric.success = true
 
         expect { collector.process(metric.to_json) }.to raise_error(ArgumentError).and output(
                 /Prometheus collector failed to process metric unknown/,
@@ -119,16 +100,16 @@ RSpec.describe DiscoursePrometheus::Collector do
 
       DiscourseEvent.trigger(
         :image_processing_finished,
-        { operation: "optimized_image_crop", result: "nonzero_exit", duration_seconds: 0.25 },
+        { operation: "optimized_image_crop", duration_seconds: 0.25, success: false },
       )
 
       metrics_text = collector.prometheus_metrics_text
 
       expect(metrics_text).to include(
         "# TYPE discourse_image_processing_command_duration_seconds histogram",
-        'discourse_image_processing_command_duration_seconds_bucket{operation="optimized_image_crop",result="nonzero_exit",le="0.25"} 1',
-        'discourse_image_processing_command_duration_seconds_count{operation="optimized_image_crop",result="nonzero_exit"} 1',
-        'discourse_image_processing_command_duration_seconds_sum{operation="optimized_image_crop",result="nonzero_exit"} 0.25',
+        'discourse_image_processing_command_duration_seconds_bucket{operation="optimized_image_crop",success="false",le="0.25"} 1',
+        'discourse_image_processing_command_duration_seconds_count{operation="optimized_image_crop",success="false"} 1',
+        'discourse_image_processing_command_duration_seconds_sum{operation="optimized_image_crop",success="false"} 0.25',
       )
     ensure
       PrometheusExporter::Metric::Base.default_prefix = original_prefix

--- a/spec/lib/image_processing_collector_spec.rb
+++ b/spec/lib/image_processing_collector_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "prometheus_exporter/server"
+require_relative "../../lib/collector"
+
+RSpec.describe DiscoursePrometheus::Collector do
+  subject(:collector) { described_class.new }
+
+  describe "#process" do
+    it "observes successful and failed image-processing results in all histograms" do
+      successful_metric = DiscoursePrometheus::InternalMetric::ImageProcessing.new
+      successful_metric.operation = "optimized_image_resize"
+      successful_metric.success = true
+      successful_metric.error_reason = "none"
+      successful_metric.duration_seconds = 0.25
+      successful_metric.cpu_seconds = 0.1
+      successful_metric.max_rss_bytes = 16.megabytes
+
+      failed_metric = DiscoursePrometheus::InternalMetric::ImageProcessing.new
+      failed_metric.operation = "topic_og_render"
+      failed_metric.success = false
+      failed_metric.error_reason = "wall_timeout"
+      failed_metric.duration_seconds = 20
+      failed_metric.cpu_seconds = 10
+      failed_metric.max_rss_bytes = 128.megabytes
+
+      collector.process(successful_metric.to_json)
+      collector.process(failed_metric.to_json)
+
+      metrics = collector.prometheus_metrics.index_by(&:name)
+      successful_labels = {
+        "operation" => "optimized_image_resize",
+        "success" => "true",
+        "error_reason" => "none",
+      }
+      failed_labels = {
+        "operation" => "topic_og_render",
+        "success" => "false",
+        "error_reason" => "wall_timeout",
+      }
+
+      expect(metrics.keys).to include(
+        "image_processing_duration_seconds",
+        "image_processing_cpu_seconds",
+        "image_processing_max_rss_bytes",
+      )
+      expect(metrics["image_processing_duration_seconds"].buckets).to eq(
+        [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30],
+      )
+      expect(metrics["image_processing_duration_seconds"].to_h).to eq(
+        successful_labels => {
+          "count" => 1,
+          "sum" => 0.25,
+        },
+        failed_labels => {
+          "count" => 1,
+          "sum" => 20.0,
+        },
+      )
+      expect(metrics["image_processing_cpu_seconds"].buckets).to eq(
+        [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300],
+      )
+      expect(metrics["image_processing_cpu_seconds"].to_h).to eq(
+        successful_labels => {
+          "count" => 1,
+          "sum" => 0.1,
+        },
+        failed_labels => {
+          "count" => 1,
+          "sum" => 10.0,
+        },
+      )
+      expect(metrics["image_processing_max_rss_bytes"].buckets).to eq(
+        [1, 4, 16, 64, 128, 256, 512, 1024, 2048, 4096].map(&:megabytes),
+      )
+      expect(metrics["image_processing_max_rss_bytes"].to_h).to eq(
+        successful_labels => {
+          "count" => 1,
+          "sum" => 16.megabytes.to_f,
+        },
+        failed_labels => {
+          "count" => 1,
+          "sum" => 128.megabytes.to_f,
+        },
+      )
+    end
+
+    it "exports an image-processing event through the public Prometheus exposition" do
+      original_prefix = PrometheusExporter::Metric::Base.default_prefix
+      PrometheusExporter::Metric::Base.default_prefix = "discourse_"
+      allow(Rails.env).to receive(:test?).and_return(false)
+      allow($prometheus_client).to receive(:send_json) do |metric|
+        collector.process(Oj.dump(metric, mode: :object))
+      end
+
+      expect(collector.prometheus_metrics_text).not_to include("discourse_image_processing")
+
+      DiscourseEvent.trigger(
+        :image_processing_finished,
+        {
+          operation: "optimized_image_crop",
+          success: false,
+          error_reason: "nonzero_exit",
+          duration_seconds: 0.25,
+          cpu_seconds: 0.1,
+          max_rss_bytes: 16.megabytes,
+        },
+      )
+
+      metrics_text = collector.prometheus_metrics_text
+
+      expect(metrics_text).to include(
+        "# TYPE discourse_image_processing_duration_seconds histogram",
+        "# TYPE discourse_image_processing_cpu_seconds histogram",
+        "# TYPE discourse_image_processing_max_rss_bytes histogram",
+        'discourse_image_processing_duration_seconds_bucket{operation="optimized_image_crop",success="false",error_reason="nonzero_exit",le="0.25"} 1',
+        'discourse_image_processing_duration_seconds_count{operation="optimized_image_crop",success="false",error_reason="nonzero_exit"} 1',
+        'discourse_image_processing_duration_seconds_sum{operation="optimized_image_crop",success="false",error_reason="nonzero_exit"} 0.25',
+      )
+    ensure
+      PrometheusExporter::Metric::Base.default_prefix = original_prefix
+    end
+  end
+end

--- a/spec/lib/image_processing_collector_spec.rb
+++ b/spec/lib/image_processing_collector_spec.rb
@@ -137,8 +137,6 @@ RSpec.describe DiscoursePrometheus::Collector do
       expect {
         DiscourseEvent.trigger(:image_processing_finished, incomplete_payload)
       }.to raise_error(KeyError, /max_rss_bytes/)
-
-      expect(collector.prometheus_metrics_text).to be_empty
     end
   end
 end

--- a/spec/lib/image_processing_collector_spec.rb
+++ b/spec/lib/image_processing_collector_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe DiscoursePrometheus::Collector do
         "error_reason" => "wall_timeout",
       }
 
-      expect(metrics.keys).to include("image_processing_command_duration_seconds")
+      expect(metrics.keys).to eq(["image_processing_command_duration_seconds"])
       expect(metrics["image_processing_command_duration_seconds"].buckets).to eq(
         [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30],
       )
@@ -64,6 +64,33 @@ RSpec.describe DiscoursePrometheus::Collector do
         metric.duration_seconds = 0.25
         metric.success = attributes[:success]
         metric.error_reason = attributes[:error_reason]
+
+        expect { collector.process(metric.to_json) }.to raise_error(ArgumentError).and output(
+                /Prometheus collector failed to process metric unknown/,
+              ).to_stderr
+      end
+
+      expect(collector.prometheus_metrics).to be_empty
+    end
+
+    it "rejects invalid operations and durations without observing them" do
+      invalid_metrics = [
+        { operation: nil, duration_seconds: 0.25 },
+        { operation: "", duration_seconds: 0.25 },
+        { operation: :optimized_image_resize, duration_seconds: 0.25 },
+        { operation: "optimized_image_resize", duration_seconds: nil },
+        { operation: "optimized_image_resize", duration_seconds: "0.25" },
+        { operation: "optimized_image_resize", duration_seconds: -0.01 },
+        { operation: "optimized_image_resize", duration_seconds: Float::NAN },
+        { operation: "optimized_image_resize", duration_seconds: Float::INFINITY },
+      ]
+
+      invalid_metrics.each do |attributes|
+        metric = DiscoursePrometheus::InternalMetric::ImageProcessing.new
+        metric.operation = attributes[:operation]
+        metric.duration_seconds = attributes[:duration_seconds]
+        metric.success = true
+        metric.error_reason = nil
 
         expect { collector.process(metric.to_json) }.to raise_error(ArgumentError).and output(
                 /Prometheus collector failed to process metric unknown/,

--- a/spec/lib/internal_metric/base_spec.rb
+++ b/spec/lib/internal_metric/base_spec.rb
@@ -40,20 +40,16 @@ RSpec.describe DiscoursePrometheus::InternalMetric::Base do
       metric = DiscoursePrometheus::InternalMetric::ImageProcessing.new
       metric.operation = "upload_auto_orient"
       metric.success = true
-      metric.error_reason = "none"
+      metric.error_reason = nil
       metric.duration_seconds = 0.5
-      metric.cpu_seconds = 0.25
-      metric.max_rss_bytes = 4.megabytes
 
       deserialized_metric = described_class.from_h(metric.to_h)
 
       expect(deserialized_metric).to have_attributes(
         operation: "upload_auto_orient",
         success: true,
-        error_reason: "none",
+        error_reason: nil,
         duration_seconds: 0.5,
-        cpu_seconds: 0.25,
-        max_rss_bytes: 4.megabytes,
       )
     end
   end

--- a/spec/lib/internal_metric/base_spec.rb
+++ b/spec/lib/internal_metric/base_spec.rb
@@ -39,15 +39,15 @@ RSpec.describe DiscoursePrometheus::InternalMetric::Base do
     it "deserializes image-processing metrics" do
       metric = DiscoursePrometheus::InternalMetric::ImageProcessing.new
       metric.operation = "upload_auto_orient"
-      metric.result = "success"
       metric.duration_seconds = 0.5
+      metric.success = true
 
       deserialized_metric = described_class.from_h(metric.to_h)
 
       expect(deserialized_metric).to have_attributes(
         operation: "upload_auto_orient",
-        result: "success",
         duration_seconds: 0.5,
+        success: true,
       )
     end
   end

--- a/spec/lib/internal_metric/base_spec.rb
+++ b/spec/lib/internal_metric/base_spec.rb
@@ -39,16 +39,14 @@ RSpec.describe DiscoursePrometheus::InternalMetric::Base do
     it "deserializes image-processing metrics" do
       metric = DiscoursePrometheus::InternalMetric::ImageProcessing.new
       metric.operation = "upload_auto_orient"
-      metric.success = true
-      metric.error_reason = nil
+      metric.result = "success"
       metric.duration_seconds = 0.5
 
       deserialized_metric = described_class.from_h(metric.to_h)
 
       expect(deserialized_metric).to have_attributes(
         operation: "upload_auto_orient",
-        success: true,
-        error_reason: nil,
+        result: "success",
         duration_seconds: 0.5,
       )
     end

--- a/spec/lib/internal_metric/base_spec.rb
+++ b/spec/lib/internal_metric/base_spec.rb
@@ -34,4 +34,27 @@ RSpec.describe DiscoursePrometheus::InternalMetric::Base do
     expect(job.class).to eq(DiscoursePrometheus::InternalMetric::Job)
     expect(job.job_name).to eq("bill")
   end
+
+  describe ".from_h" do
+    it "deserializes image-processing metrics" do
+      metric = DiscoursePrometheus::InternalMetric::ImageProcessing.new
+      metric.operation = "upload_auto_orient"
+      metric.success = true
+      metric.error_reason = "none"
+      metric.duration_seconds = 0.5
+      metric.cpu_seconds = 0.25
+      metric.max_rss_bytes = 4.megabytes
+
+      deserialized_metric = described_class.from_h(metric.to_h)
+
+      expect(deserialized_metric).to have_attributes(
+        operation: "upload_auto_orient",
+        success: true,
+        error_reason: "none",
+        duration_seconds: 0.5,
+        cpu_seconds: 0.25,
+        max_rss_bytes: 4.megabytes,
+      )
+    end
+  end
 end

--- a/spec/lib/reporter/image_processing_spec.rb
+++ b/spec/lib/reporter/image_processing_spec.rb
@@ -10,8 +10,6 @@ RSpec.describe DiscoursePrometheus::Reporter::ImageProcessing do
         success: false,
         error_reason: "nonzero_exit",
         duration_seconds: 1.25,
-        cpu_seconds: 0.75,
-        max_rss_bytes: 64.megabytes,
       }
 
       client.expects(:send_json).with(payload.merge(_type: "ImageProcessing"))
@@ -24,17 +22,11 @@ RSpec.describe DiscoursePrometheus::Reporter::ImageProcessing do
     it "rejects incomplete events without reporting observations" do
       allow(Rails.env).to receive(:test?).and_return(false)
       $prometheus_client.expects(:send_json).never
-      incomplete_payload = {
-        operation: "optimized_image_resize",
-        success: true,
-        error_reason: "none",
-        duration_seconds: 0.25,
-        cpu_seconds: 0.1,
-      }
+      incomplete_payload = { operation: "optimized_image_resize", success: true, error_reason: nil }
 
       expect {
         DiscourseEvent.trigger(:image_processing_finished, incomplete_payload)
-      }.to raise_error(KeyError, /max_rss_bytes/)
+      }.to raise_error(KeyError, /duration_seconds/)
     end
   end
 end

--- a/spec/lib/reporter/image_processing_spec.rb
+++ b/spec/lib/reporter/image_processing_spec.rb
@@ -19,14 +19,21 @@ RSpec.describe DiscoursePrometheus::Reporter::ImageProcessing do
   end
 
   describe ":image_processing_finished" do
-    it "rejects incomplete events without reporting observations" do
+    it "rejects events missing an operation or duration without reporting observations" do
       allow(Rails.env).to receive(:test?).and_return(false)
       $prometheus_client.expects(:send_json).never
-      incomplete_payload = { operation: "optimized_image_resize", success: true, error_reason: nil }
+      payload = {
+        operation: "optimized_image_resize",
+        success: true,
+        error_reason: nil,
+        duration_seconds: 0.25,
+      }
 
-      expect {
-        DiscourseEvent.trigger(:image_processing_finished, incomplete_payload)
-      }.to raise_error(KeyError, /duration_seconds/)
+      %i[operation duration_seconds].each do |missing_attribute|
+        expect {
+          DiscourseEvent.trigger(:image_processing_finished, payload.except(missing_attribute))
+        }.to raise_error(KeyError, /#{missing_attribute}/)
+      end
     end
   end
 end

--- a/spec/lib/reporter/image_processing_spec.rb
+++ b/spec/lib/reporter/image_processing_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe DiscoursePrometheus::Reporter::ImageProcessing do
       reporter = described_class.new(client)
       payload = {
         operation: "optimized_image_resize",
-        success: false,
-        error_reason: "nonzero_exit",
+        result: "nonzero_exit",
         duration_seconds: 1.25,
       }
 
@@ -19,17 +18,12 @@ RSpec.describe DiscoursePrometheus::Reporter::ImageProcessing do
   end
 
   describe ":image_processing_finished" do
-    it "rejects events missing an operation or duration without reporting observations" do
+    it "rejects incomplete events without reporting observations" do
       allow(Rails.env).to receive(:test?).and_return(false)
       $prometheus_client.expects(:send_json).never
-      payload = {
-        operation: "optimized_image_resize",
-        success: true,
-        error_reason: nil,
-        duration_seconds: 0.25,
-      }
+      payload = { operation: "optimized_image_resize", result: "success", duration_seconds: 0.25 }
 
-      %i[operation duration_seconds].each do |missing_attribute|
+      %i[operation result duration_seconds].each do |missing_attribute|
         expect {
           DiscourseEvent.trigger(:image_processing_finished, payload.except(missing_attribute))
         }.to raise_error(KeyError, /#{missing_attribute}/)

--- a/spec/lib/reporter/image_processing_spec.rb
+++ b/spec/lib/reporter/image_processing_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscoursePrometheus::Reporter::ImageProcessing do
+  describe "#report" do
+    it "sends an image-processing metric to the collector" do
+      client = mock
+      reporter = described_class.new(client)
+      payload = {
+        operation: "optimized_image_resize",
+        success: false,
+        error_reason: "nonzero_exit",
+        duration_seconds: 1.25,
+        cpu_seconds: 0.75,
+        max_rss_bytes: 64.megabytes,
+      }
+
+      client.expects(:send_json).with(payload.merge(_type: "ImageProcessing"))
+
+      expect(reporter.report(payload)).to be_nil
+    end
+  end
+end

--- a/spec/lib/reporter/image_processing_spec.rb
+++ b/spec/lib/reporter/image_processing_spec.rb
@@ -5,11 +5,7 @@ RSpec.describe DiscoursePrometheus::Reporter::ImageProcessing do
     it "sends an image-processing metric to the collector" do
       client = mock
       reporter = described_class.new(client)
-      payload = {
-        operation: "optimized_image_resize",
-        result: "nonzero_exit",
-        duration_seconds: 1.25,
-      }
+      payload = { operation: "optimized_image_resize", duration_seconds: 1.25, success: false }
 
       client.expects(:send_json).with(payload.merge(_type: "ImageProcessing"))
 
@@ -21,9 +17,9 @@ RSpec.describe DiscoursePrometheus::Reporter::ImageProcessing do
     it "rejects incomplete events without reporting observations" do
       allow(Rails.env).to receive(:test?).and_return(false)
       $prometheus_client.expects(:send_json).never
-      payload = { operation: "optimized_image_resize", result: "success", duration_seconds: 0.25 }
+      payload = { operation: "optimized_image_resize", duration_seconds: 0.25, success: true }
 
-      %i[operation result duration_seconds].each do |missing_attribute|
+      %i[operation duration_seconds success].each do |missing_attribute|
         expect {
           DiscourseEvent.trigger(:image_processing_finished, payload.except(missing_attribute))
         }.to raise_error(KeyError, /#{missing_attribute}/)

--- a/spec/lib/reporter/image_processing_spec.rb
+++ b/spec/lib/reporter/image_processing_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe DiscoursePrometheus::Reporter::ImageProcessing do
 
   describe ":image_processing_finished" do
     it "rejects incomplete events without reporting observations" do
-      allow(Rails.env).to receive(:test?).and_return(false)
       $prometheus_client.expects(:send_json).never
       payload = { operation: "optimized_image_resize", duration_seconds: 0.25, success: true }
 

--- a/spec/lib/reporter/image_processing_spec.rb
+++ b/spec/lib/reporter/image_processing_spec.rb
@@ -19,4 +19,22 @@ RSpec.describe DiscoursePrometheus::Reporter::ImageProcessing do
       expect(reporter.report(payload)).to be_nil
     end
   end
+
+  describe ":image_processing_finished" do
+    it "rejects incomplete events without reporting observations" do
+      allow(Rails.env).to receive(:test?).and_return(false)
+      $prometheus_client.expects(:send_json).never
+      incomplete_payload = {
+        operation: "optimized_image_resize",
+        success: true,
+        error_reason: "none",
+        duration_seconds: 0.25,
+        cpu_seconds: 0.1,
+      }
+
+      expect {
+        DiscourseEvent.trigger(:image_processing_finished, incomplete_payload)
+      }.to raise_error(KeyError, /max_rss_bytes/)
+    end
+  end
 end


### PR DESCRIPTION
Exports `discourse_image_processing_duration_seconds` as a histogram labeled by `operation` and `success`.